### PR TITLE
Add keep-alive messages to the StreamableHTTP transport

### DIFF
--- a/lib/anubis/server/transport/streamable_http.ex
+++ b/lib/anubis/server/transport/streamable_http.ex
@@ -75,7 +75,8 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
     {:name, {:required, {:custom, &Anubis.genserver_name/1}}},
     {:registry, {:atom, {:default, Anubis.Server.Registry}}},
     {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}},
-    {:task_supervisor, {:required, {:custom, &Anubis.genserver_name/1}}}
+    {:task_supervisor, {:required, {:custom, &Anubis.genserver_name/1}}},
+    {:keep_alive_interval, {:integer, {:default, to_timeout(second: 30)}}}
   ])
 
   @doc """
@@ -208,10 +209,15 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
       registry: opts.registry,
       request_timeout: opts.request_timeout,
       task_supervisor: opts.task_supervisor,
+      keep_alive_interval: opts.keep_alive_interval,
       # Map of session_id => {pid, monitor_ref}
       sse_handlers: %{},
       active_tasks: %{}
     }
+
+    # Start keep-alive timer
+    timer_ref = Process.send_after(self(), :keep_alive, opts.keep_alive_interval)
+    state = Map.put(state, :keep_alive_timer, timer_ref)
 
     Logger.metadata(mcp_transport: :streamable_http, mcp_server: server)
 
@@ -409,7 +415,24 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
     {:noreply, %{state | active_tasks: active_tasks}}
   end
 
-  def handle_info({_ref, _}, state), do: {:noreply, state}
+  # Handle keep-alive timer
+  def handle_info(:keep_alive, %{keep_alive_interval: interval, sse_handlers: handlers} = state) do
+    for {_session_id, {pid, _ref}} <- handlers do
+      send(pid, :sse_keep_alive)
+    end
+
+    # Restart timer for next interval
+    timer_ref = Process.send_after(self(), :keep_alive, interval)
+    state = Map.put(state, :keep_alive_timer, timer_ref)
+
+    Logging.transport_event("keep_alive_sent", %{
+      active_handlers: map_size(handlers)
+    })
+
+    {:noreply, state}
+  end
+
+  def handle_info(_msg, state), do: {:noreply, state}
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{active_tasks: active_tasks} = state)
       when is_map_key(active_tasks, ref) do
@@ -449,7 +472,12 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
   end
 
   @impl GenServer
-  def terminate(reason, _state) do
+  def terminate(reason, state) do
+    # Cancel keep-alive timer if it exists
+    if Map.has_key?(state, :keep_alive_timer) do
+      Process.cancel_timer(state.keep_alive_timer)
+    end
+
     Telemetry.execute(
       Telemetry.event_transport_terminate(),
       %{system_time: System.system_time()},

--- a/lib/anubis/server/transport/streamable_http.ex
+++ b/lib/anubis/server/transport/streamable_http.ex
@@ -432,8 +432,6 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
     {:noreply, state}
   end
 
-  def handle_info(_msg, state), do: {:noreply, state}
-
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{active_tasks: active_tasks} = state)
       when is_map_key(active_tasks, ref) do
     {task_info, active_tasks} = Map.pop(active_tasks, ref)

--- a/lib/anubis/sse/streaming.ex
+++ b/lib/anubis/sse/streaming.ex
@@ -74,6 +74,13 @@ if Code.ensure_loaded?(Plug) do
       end
     end
 
+    def send_keep_alive(conn) do
+      case Plug.Conn.chunk(conn, ": keep-alive\n\n") do
+        {:ok, conn} -> {:ok, conn}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+
     # Private functions
 
     defp loop(conn, transport, session_id, event_counter) do
@@ -94,6 +101,12 @@ if Code.ensure_loaded?(Plug) do
               )
 
               conn
+          end
+
+        :sse_keep_alive ->
+          case send_keep_alive(conn) do
+            {:ok, conn} ->
+              loop(conn, transport, session_id, event_counter)
           end
 
         :close_sse ->

--- a/lib/anubis/sse/streaming.ex
+++ b/lib/anubis/sse/streaming.ex
@@ -107,6 +107,18 @@ if Code.ensure_loaded?(Plug) do
           case send_keep_alive(conn) do
             {:ok, conn} ->
               loop(conn, transport, session_id, event_counter)
+
+            {:error, reason} ->
+              Logging.transport_event(
+                "sse_keep_alive_failed",
+                %{
+                  session_id: session_id,
+                  reason: reason
+                },
+                level: :error
+              )
+
+              conn
           end
 
         :close_sse ->


### PR DESCRIPTION
## Problem

Problem is described in https://github.com/zoedsoupe/anubis-mcp/issues/10

## Solution

Add keep-alive messages to prevent the connection from closing.

### Note

I could also include a comment about setting `reset_idle_timeout_on_send: true` if they are using `Plug.Cowboy`
