### PR TITLE
Add tool call_timeout and better authentication enforcement

### DIFF
--- a/pages/recipes.md
+++ b/pages/recipes.md
@@ -15,17 +15,17 @@ defmodule MyApp.AuthenticatedServer do
     version: "1.0.0",
     capabilities: [:tools]
 
-  def init(arg, frame) do
-    # Check API key from transport metadata
-    api_key = get_in(frame.transport, [:headers, "x-api-key"])
+  def validate_initialize(arg, frame) do
+    # Check Authorization header
+    auth_header = Anubis.Server.Frame.get_req_header(frame, "authorization")
 
-    case authenticate_api_key(api_key) do
+    case authenticate_api_key(auth_header) do
       {:ok, user} ->
         # Store user in frame assigns for later use
         {:ok, Map.put(frame, :assigns, %{user: user})}
 
-      :error ->
-        {:stop, :unauthorized}
+      _ ->
+        {:error, Anubis.MCP.Error.transport(:unauthorized)}
     end
   end
 


### PR DESCRIPTION
## Problem

- The described init/2 method for enforcing authentication does not work. `{:error, term()}` is not a supported return value. 
- Tool calls that take longer than 5 seconds will fail due to timeout. 

## Solution

- Add new `validate_initialize` callback that can run during the initialize handshake that will correctly error out the client/server handshake. 
- Be able to set a call timeout in your frame (via `init/2` or `validate_initialize/2` to be used during the session. 

## Rationale

- For `validate_initialize/2`, I wanted to make sure there was a way to prevent client connections entirely. An attempt to fix the `init/2` implementation would not prevent clients from connecting to the server if they were unauthorized. 
- For the `call_timeout` setting, I wanted to minimize the footprint and provide a clean way to set a default timeout across the board. 
