### PR TITLE
fix: output schemas should not validate on error resps

### DIFF
--- a/lib/anubis/server/handlers/tools.ex
+++ b/lib/anubis/server/handlers/tools.ex
@@ -93,6 +93,10 @@ defmodule Anubis.Server.Handlers.Tools do
     {:reply, Response.to_protocol(resp), frame}
   end
 
+  defp maybe_validate_output_schema(_tool, %Response{isError: true} = resp, frame) do
+    {:reply, Response.to_protocol(resp), frame}
+  end
+
   defp maybe_validate_output_schema(%Tool{} = tool, %Response{structured_content: nil}, frame) do
     metadata = %{tool_name: tool.name}
     {:error, Error.execution(@output_schema_err, metadata), frame}

--- a/test/anubis/server/component/tool_annotations_test.exs
+++ b/test/anubis/server/component/tool_annotations_test.exs
@@ -252,6 +252,22 @@ defmodule Anubis.Server.Component.ToolAnnotationsTest do
       assert result["isError"] == false
     end
 
+    test "tool error response skips output schema validation", %{
+      server: server,
+      session_id: session_id
+    } do
+      request =
+        build_request("tools/call", %{
+          "name" => "tool_with_output_schema",
+          "arguments" => %{"query" => "tool error"}
+        })
+
+      {:ok, response_string} =
+        GenServer.call(server, {:request, request, session_id, %{}})
+
+      assert {:ok, [%{"result" => %{"isError" => true}}]} = Message.decode(response_string)
+    end
+
     test "tool without output schema works normally", %{
       server: server,
       session_id: session_id

--- a/test/support/test_tools.ex
+++ b/test/support/test_tools.ex
@@ -278,6 +278,10 @@ defmodule ToolWithOutputSchema do
   end
 
   @impl true
+  def execute(%{query: "tool error"}, frame) do
+    {:reply, Response.error(Response.tool(), "Tool error"), frame}
+  end
+
   def execute(%{query: query}, frame) do
     results = %{
       results: [


### PR DESCRIPTION
## Problem

<!-- what problem is the PR is trying to solve? -->

## Solution

<!-- how is the PR solving the problem? -->

## Rationale

Port of https://github.com/cloudwalk/hermes-mcp/pull/225
