### PR TITLE
fix: correct capability parsing to nest options under capability keys

### DIFF
--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -668,28 +668,20 @@ defmodule Anubis.Server do
     subscribe? = opts[:subscribe?]
     list_changed? = opts[:list_changed?]
 
-    capabilities
-    |> Map.put("resources", %{})
-    |> then(&if(is_nil(subscribe?), do: &1, else: Map.put(&1, :subscribe, subscribe?)))
-    |> then(
-      &if(is_nil(list_changed?),
-        do: &1,
-        else: Map.put(&1, :listChanged, list_changed?)
-      )
-    )
+    resources_config =
+      %{}
+      |> then(&if(is_nil(subscribe?), do: &1, else: Map.put(&1, :subscribe, subscribe?)))
+      |> then(&if(is_nil(list_changed?), do: &1, else: Map.put(&1, :listChanged, list_changed?)))
+
+    Map.put(capabilities, "resources", resources_config)
   end
 
   def parse_capability({capability, opts}, %{} = capabilities) when is_server_capability(capability) do
     list_changed? = opts[:list_changed?]
 
-    capabilities
-    |> Map.put(to_string(capability), %{})
-    |> then(
-      &if(is_nil(list_changed?),
-        do: &1,
-        else: Map.put(&1, :listChanged, list_changed?)
-      )
-    )
+    capability_config = if is_nil(list_changed?), do: %{}, else: %{listChanged: list_changed?}
+
+    Map.put(capabilities, to_string(capability), capability_config)
   end
 
   @doc false


### PR DESCRIPTION
Hi! 👋 
First off, thank you so much for creating and maintaining Anubis, I really appreciate the effort you've put into this library, especially given how rapidly the MCP specification is evolving.

I noticed a small issue with server `capability` parsing where options weren't being properly nested under their respective capability keys, so I've submitted this PR.

Let me know if the change makes sense and if there is anything else I should add/change.

Thanks again, cheers ✌️ 

---

## Problem

Capability options like "subscribe" and "listChanged" are placed directly on the capabilities map (root level) instead of nested under their respective capability keys (resources, prompts, etc). This resulted in incorrect MCP protocol structure.

## Solution

When configuring the server as following:

```elixir
  use(Anubis.Server,
    name: "app-name",
    version: "1.0.0",
    capabilities: %{
      tools: %{},
      resources: %{subscribe?: true, list_changed?: true},
      prompts: %{}
    }
  )
```

The current implementation (`main` branch) returns this:

```elixir
"capabilities": {
  "subscribe": true,
  "listChanged": true,
  "resources": {}
}
```

While, with the proposed fix:

```
{
  "capabilities": {
    "resources": {
      "subscribe": true,
      "listChanged": true
    }
  }
}
```

## Rationale

Properly compose the MCP server `capability`.
