### PR TITLE
feat(redis): add redix_opts for SSL/TLS support

### DIFF
--- a/lib/anubis/server/session/store/redis.ex
+++ b/lib/anubis/server/session/store/redis.ex
@@ -112,7 +112,7 @@ defmodule Anubis.Server.Session.Store.Redis do
       opts
       |> Keyword.get(:redix_opts, [])
       |> validate_redix_opts()
-      |> Keyword.drop([:name])
+      |> Keyword.delete(:name)
 
     # Start Redix connection pool with anubis_ prefix to avoid conflicts
     children =
@@ -121,13 +121,7 @@ defmodule Anubis.Server.Session.Store.Redis do
 
         # Default Redix options, merged with custom options (custom takes precedence)
         # Note: :name is always set internally to maintain pool integrity
-        redix_opts =
-          [
-            name: child_id,
-            sync_connect: false,
-            exit_on_disconnection: false
-          ]
-          |> Keyword.merge(custom_redix_opts)
+        redix_opts = Keyword.merge([name: child_id, sync_connect: false, exit_on_disconnection: false], custom_redix_opts)
 
         %{
           id: child_id,


### PR DESCRIPTION
## Summary

Add `:redix_opts` configuration option to Redis session store that allows passing custom Redix connection options. This enables connecting to cloud Redis providers requiring SSL/TLS with custom hostname verification (like Upstash, Redis Enterprise, etc.).

## Problem

The Redis session store currently hardcodes Redix connection options, making it impossible to connect to cloud Redis providers that require SSL/TLS with custom hostname verification.

Upstash and similar providers use wildcard SSL certificates (e.g., `*.upstash.io`) which require custom hostname verification. Currently, users must create a full custom adapter (~400 lines) just to add SSL options.

## Solution

Add a `:redix_opts` configuration option that merges with the default Redix options:

```elixir
config :anubis_mcp, :session_store,
  adapter: Anubis.Server.Session.Store.Redis,
  redis_url: "rediss://default:password@host.upstash.io:6379",
  redix_opts: [
    ssl: true,
    socket_opts: [
      customize_hostname_check: [
        match_fun: :public_key.pkix_verify_hostname_match_fun(:https)
      ]
    ]
  ]
```

## Changes

- Extract `custom_redix_opts` from config options (defaults to `[]`)
- Merge custom options with defaults (custom takes precedence)
- Document SSL/TLS configuration in moduledoc

## Test plan

- [x] Existing tests pass (no breaking changes - defaults unchanged)
- [x] Tested with Upstash Redis in production environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session store supports per-pool Redis client options in configuration; custom options are merged with sensible defaults and applied per pool.
* **Validation**
  * Configuration now validates supplied Redis client option formats to surface misconfiguration early.
* **Documentation**
  * Docs updated with SSL/TLS examples for common providers (e.g., Upstash).
* **Notes**
  * No public APIs or exported signatures were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->