### PR TITLE
✨ fix(stdio): hide console window on windows

### DIFF
--- a/lib/anubis/transport/stdio.ex
+++ b/lib/anubis/transport/stdio.ex
@@ -278,6 +278,7 @@ defmodule Anubis.Transport.STDIO do
       |> then(&if is_nil(state.args), do: &1, else: Enum.concat(&1, args: state.args))
       |> then(&if is_nil(state.env), do: &1, else: Enum.concat(&1, env: env))
       |> then(&if is_nil(state.cwd), do: &1, else: Enum.concat(&1, cd: state.cwd))
+      |> then(&if :os.type() == {:win32, :nt}, do: [{:hide, true} | &1], else: &1)
 
     Port.open({:spawn_executable, cmd}, opts)
   end


### PR DESCRIPTION
Hi! Thank you for creating this project, it's been a lifesaver for implementing MCP on my personal coding agent, Opal.

A little quirk on Windows: when running stdio MCP tools, open_port with spawn_executable opens a visible console window for each spawned process on Windows, which is a bit awkward.

This PR adds the optional hide flag which suppresses this problem.

Thank you and cheers!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * On Windows, spawned background processes no longer reveal a console window, producing a quieter, cleaner experience when launching external tools. Existing non-Windows behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->