### PR TITLE
fix: prevent session restore loop crashing pods

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 27.3
-elixir 1.18.3-otp-27
+erlang 28.0.1
+elixir 1.18.4-otp-28

--- a/lib/anubis/server/base.ex
+++ b/lib/anubis/server/base.ex
@@ -132,6 +132,15 @@ defmodule Anubis.Server.Base do
           if request_id, do: Session.complete_request(session.name, request_id)
           {:reply, {:error, error}, new_state}
       end
+    else
+      {:error, reason} ->
+        Logging.server_event("session_attach_failed", %{
+          session_id: session_id,
+          reason: inspect(reason)
+        }, level: :error)
+
+        error = Error.protocol(:internal_error, %{message: "Failed to attach session"})
+        {:reply, {:ok, Error.build_json_rpc(error, decoded["id"])}, state}
     end
   end
 
@@ -172,6 +181,14 @@ defmodule Anubis.Server.Base do
 
         {:noreply, state}
       end
+    else
+      {:error, reason} ->
+        Logging.server_event("session_attach_failed", %{
+          session_id: session_id,
+          reason: inspect(reason)
+        }, level: :error)
+
+        {:noreply, state}
     end
   end
 

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -9,6 +9,7 @@ defmodule Anubis.Server.Session do
   @type t :: %__MODULE__{
           protocol_version: String.t() | nil,
           protocol_module: module() | nil,
+          server_module: module() | nil,
           initialized: boolean(),
           name: GenServer.name() | nil,
           client_info: map() | nil,
@@ -24,6 +25,7 @@ defmodule Anubis.Server.Session do
     :id,
     :protocol_version,
     :protocol_module,
+    :server_module,
     :log_level,
     :name,
     initialized: false,
@@ -35,6 +37,7 @@ defmodule Anubis.Server.Session do
   defschema :state_t, %{
     protocol_version: :string,
     protocol_module: :atom,
+    server_module: :atom,
     initialized: {:required, :boolean},
     name: {:custom, &Anubis.genserver_name/1},
     client_info: :map,
@@ -67,7 +70,7 @@ defmodule Anubis.Server.Session do
           state
 
         {:error, _reason} ->
-          new(id: session_id, name: name)
+          new(id: session_id, name: name, server_module: server_module)
       end
 
     Agent.start_link(fn -> initial_state end, name: name)

--- a/lib/anubis/server/session/store/redis.ex
+++ b/lib/anubis/server/session/store/redis.ex
@@ -235,7 +235,7 @@ if Code.ensure_loaded?(Redix) do
           session_ids =
             keys
             |> Enum.map(&extract_session_id(state.namespace, &1))
-            |> filter_by_server(server_filter)
+            |> filter_by_server(server_filter, state)
 
           {:reply, {:ok, session_ids}, state}
 
@@ -417,13 +417,23 @@ if Code.ensure_loaded?(Redix) do
       end
     end
 
-    defp filter_by_server(session_ids, nil), do: session_ids
+    defp filter_by_server(session_ids, nil, _state), do: session_ids
 
-    defp filter_by_server(session_ids, server) do
-      # If we need server-specific filtering, we'd need to load each session
-      # and check its server field. For now, return all.
-      _ = server
-      session_ids
+    defp filter_by_server(session_ids, server, state) do
+      server_string = to_string(server)
+
+      Enum.filter(session_ids, fn session_id ->
+        key = make_key(state.namespace, session_id)
+
+        case load_and_decode(state, key) do
+          {:ok, data} ->
+            stored_server = data["server_module"] || data[:server_module]
+            is_nil(stored_server) or to_string(stored_server) == server_string
+
+          _error ->
+            false
+        end
+      end)
     end
   end
 end


### PR DESCRIPTION
- Add else clauses to with statements in Base.handle_call and handle_cast for maybe_attach_session, preventing :bad_return_value crashes that trigger one_for_all supervisor restart cascades
- Add server_module field to Session struct so sessions are persisted with their server identity
- Implement filter_by_server in Redis store to only restore sessions belonging to the current server

## Problem

<!-- what problem is the PR is trying to solve? -->

## Solution

<!-- how is the PR solving the problem? -->

## Rationale

<!-- why was it implemented the way it was? -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Erlang to version 28.0.1 and Elixir to version 1.18.4

* **Bug Fixes**
  * Improved error handling for session attachment failures with enhanced logging and recovery
  * Refined session filtering logic for better accuracy in session management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->