### PR TITLE
Fix misleading session store warning when disabled

### DIFF
--- a/lib/anubis/application.ex
+++ b/lib/anubis/application.ex
@@ -28,21 +28,36 @@ defmodule Anubis.Application do
   end
 
   defp maybe_start_session_store do
-    if adapter = Anubis.get_session_store_adapter() do
-      config = Application.get_env(:anubis_mcp, :session_store)
+    config = Application.get_env(:anubis_mcp, :session_store, [])
+    session_store_children(config)
+  end
 
-      Anubis.Logging.log(:info, "Starting session store",
-        enabled: true,
-        adapter: adapter,
-        ttl: Keyword.get(config, :ttl),
-        namespace: Keyword.get(config, :namespace)
-      )
+  @doc false
+  def session_store_children(config) when is_list(config) do
+    enabled? = Keyword.get(config, :enabled, false)
+    adapter = Keyword.get(config, :adapter)
 
-      [{adapter, config}]
-    else
-      Anubis.Logging.log(:warning, "Session store enabled but adapter not available", adapter: adapter)
+    cond do
+      not enabled? ->
+        []
 
-      []
+      is_nil(adapter) ->
+        Anubis.Logging.log(:warning, "Session store enabled but adapter not configured", [])
+        []
+
+      Code.ensure_loaded?(adapter) ->
+        Anubis.Logging.log(:info, "Starting session store",
+          enabled: true,
+          adapter: adapter,
+          ttl: Keyword.get(config, :ttl),
+          namespace: Keyword.get(config, :namespace)
+        )
+
+        [{adapter, config}]
+
+      true ->
+        Anubis.Logging.log(:warning, "Session store enabled but adapter not available", adapter: adapter)
+        []
     end
   end
 end

--- a/test/anubis/application_test.exs
+++ b/test/anubis/application_test.exs
@@ -1,0 +1,53 @@
+defmodule Anubis.ApplicationTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Anubis.Test.MockSessionStore
+
+  test "does not log warning when session store is disabled" do
+    config = [enabled: false, adapter: MockSessionStore]
+
+    log =
+      capture_log(fn ->
+        assert [] == Anubis.Application.session_store_children(config)
+      end)
+
+    refute log =~ "Session store enabled but adapter not available"
+    refute log =~ "Session store enabled but adapter not configured"
+  end
+
+  test "logs warning when session store is enabled but adapter is nil" do
+    config = [enabled: true]
+
+    log =
+      capture_log(fn ->
+        assert [] == Anubis.Application.session_store_children(config)
+      end)
+
+    assert log =~ "Session store enabled but adapter not configured"
+  end
+
+  test "logs warning when session store is enabled but adapter is unavailable" do
+    config = [enabled: true, adapter: NonExisting.Adapter]
+
+    log =
+      capture_log(fn ->
+        assert [] == Anubis.Application.session_store_children(config)
+      end)
+
+    assert log =~ "Session store enabled but adapter not available"
+  end
+
+  test "returns child spec when session store is enabled and adapter is available" do
+    config = [enabled: true, adapter: MockSessionStore, ttl: 1_800_000, namespace: "anubis:sessions"]
+
+    log =
+      capture_log(fn ->
+        assert [{MockSessionStore, config}] == Anubis.Application.session_store_children(config)
+      end)
+
+    assert log =~ "Starting session store"
+    refute log =~ "Session store enabled but adapter not available"
+  end
+end


### PR DESCRIPTION
## Problem

Warning `Session store enabled but adapter not available` when the session store
is not enabled.

## Solution

Properly check the config's `enabled` boolean param

## Rationale




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored session store initialization to improve configuration handling and logging.
* **Tests**
  * Added test coverage for session store configuration scenarios and related logging.
* **Note**
  * No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->