### PR TITLE
docs: correct supervision tree setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ end
 
 # Add to your application supervisor
 children = [
-  Anubis.Server.Registry,
   {MyApp.MCPServer, transport: :streamable_http}
 ]
 

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -37,7 +37,7 @@ defmodule Anubis.Server do
       end
 
       # In your supervision tree
-      children = [Anubis.Server.Registry, {MyServer, transport: :stdio}]
+      children = [{MyServer, transport: :stdio}]
       Supervisor.start_link(children, strategy: :one_for_one)
 
   Your server is now a living process that AI assistants can connect to, discover available

--- a/pages/building-a-server.md
+++ b/pages/building-a-server.md
@@ -89,7 +89,7 @@ defmodule MyApp.Server do
   component MyApp.Greeter
 end
 
-children = [Anubis.Server.Registry, {MyApp.Server, transport: :stdio}]
+children = [{MyApp.Server, transport: :stdio}]
 {:ok, _pid} = Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)
 ```
 
@@ -447,7 +447,6 @@ end
 # In your application supervisor
 children = [
   MyAppWeb.Endpoint,
-  Anubis.Server.Registry,
   {MyApp.Server, transport: :streamable_http}
 ]
 ```


### PR DESCRIPTION
## Problem

The documentation was incorrect. You don't need to list `Registry` in your application's supervision tree. 

Fixes #116 

## Solution

Update the docs to be correct

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated server configuration examples in README, module documentation, and build guides to reflect a simplified supervision tree setup approach.
  * Removed the explicit registry component from quick-start and integration code samples, resulting in a streamlined server initialization process with clearer setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->