### PR TITLE
feat: add instructions field to initialize response

### DIFF
--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -488,6 +488,7 @@ defmodule Anubis.Server do
     end
   end
 
+  @doc false
   defp maybe_define_server_instructions(module, instructions) do
     if not Module.defines?(module, {:server_instructions, 0}) do
       quote do

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -174,6 +174,17 @@ defmodule Anubis.Server do
   @callback server_capabilities :: server_capabilities()
   @callback supported_protocol_versions() :: [String.t()]
 
+  @doc """
+  Returns optional instructions describing how to use the server and its features.
+
+  This can be used by clients to improve the LLM's understanding of available tools,
+  resources, etc. It can be thought of like a "hint" to the model. For example, this
+  information MAY be added to the system prompt.
+
+  Return `nil` to omit the instructions field from the initialize response.
+  """
+  @callback server_instructions() :: String.t() | nil
+
   @callback handle_info(event :: term, Frame.t()) ::
               {:noreply, Frame.t()}
               | {:noreply, Frame.t(), timeout() | :hibernate | {:continue, arg :: term}}
@@ -226,7 +237,8 @@ defmodule Anubis.Server do
                       init: 2,
                       handle_sampling: 3,
                       handle_completion: 3,
-                      handle_roots: 3
+                      handle_roots: 3,
+                      server_instructions: 0
 
   @doc false
   defguard is_server_capability(capability) when capability in @server_capabilities
@@ -316,6 +328,7 @@ defmodule Anubis.Server do
       unquote(maybe_define_server_info(env.module, opts[:name], opts[:version]))
       unquote(maybe_define_server_capabilities(env.module, opts[:capabilities]))
       unquote(maybe_define_protocol_versions(env.module, opts[:protocol_versions]))
+      unquote(maybe_define_server_instructions(env.module, opts[:instructions]))
 
       defoverridable handle_request: 2
     end
@@ -471,6 +484,15 @@ defmodule Anubis.Server do
       quote do
         @impl Anubis.Server
         def supported_protocol_versions, do: unquote(versions)
+      end
+    end
+  end
+
+  defp maybe_define_server_instructions(module, instructions) do
+    if not Module.defines?(module, {:server_instructions, 0}) do
+      quote do
+        @impl Anubis.Server
+        def server_instructions, do: unquote(instructions)
       end
     end
   end

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -40,6 +40,7 @@ defmodule Anubis.Server.Session do
           frame: Frame.t(),
           server_info: map(),
           capabilities: map(),
+          instructions: String.t() | nil,
           supported_versions: list(String.t()),
           transport: %{layer: module(), name: GenServer.name()},
           registry: module(),
@@ -1008,5 +1009,7 @@ defmodule Anubis.Server.Session do
   end
 
   defp maybe_put_instructions(result, nil), do: result
-  defp maybe_put_instructions(result, instructions), do: Map.put(result, "instructions", instructions)
+
+  defp maybe_put_instructions(result, instructions) when is_binary(instructions),
+    do: Map.put(result, "instructions", instructions)
 end

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -99,6 +99,7 @@ defmodule Anubis.Server.Session do
     server_info = module.server_info()
     capabilities = module.server_capabilities()
     protocol_versions = module.supported_protocol_versions()
+    instructions = module.server_instructions()
 
     state = %{
       session_id: opts.session_id,
@@ -112,6 +113,7 @@ defmodule Anubis.Server.Session do
       frame: Frame.new(),
       server_info: server_info,
       capabilities: capabilities,
+      instructions: instructions,
       supported_versions: protocol_versions,
       transport: Map.new(opts.transport),
       registry: opts.registry,
@@ -409,11 +411,11 @@ defmodule Anubis.Server.Session do
 
     maybe_persist_session(state)
 
-    result = %{
-      "protocolVersion" => protocol_version,
-      "serverInfo" => state.server_info,
-      "capabilities" => state.capabilities
-    }
+    result =
+      maybe_put_instructions(
+        %{"protocolVersion" => protocol_version, "serverInfo" => state.server_info, "capabilities" => state.capabilities},
+        state.instructions
+      )
 
     Logging.server_event("initializing", %{
       client_info: client_info,
@@ -1004,4 +1006,7 @@ defmodule Anubis.Server.Session do
       %{id: id, method: req[:method]}
     end)
   end
+
+  defp maybe_put_instructions(result, nil), do: result
+  defp maybe_put_instructions(result, instructions), do: Map.put(result, "instructions", instructions)
 end

--- a/test/anubis/server/session_instructions_test.exs
+++ b/test/anubis/server/session_instructions_test.exs
@@ -1,0 +1,122 @@
+defmodule Anubis.Server.SessionInstructionsTest do
+  use Anubis.MCP.Case, async: false
+
+  alias Anubis.MCP.Message
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Session
+
+  require Message
+
+  @moduletag capture_log: true
+
+  defmodule InstructionsViaOptionServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "instructions-option-server",
+      version: "1.0.0",
+      capabilities: [:tools],
+      instructions: "Use this server to look up user accounts. Always confirm before deleting."
+  end
+
+  defmodule InstructionsViaCallbackServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "instructions-callback-server",
+      version: "1.0.0",
+      capabilities: [:tools]
+
+    @impl Anubis.Server
+    def server_instructions do
+      "Dynamic instructions from callback"
+    end
+  end
+
+  defmodule NoInstructionsServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "no-instructions-server",
+      version: "1.0.0",
+      capabilities: [:tools]
+  end
+
+  describe "instructions via use option" do
+    test "initialize response includes instructions" do
+      {session, _transport} = start_session(InstructionsViaOptionServer)
+
+      result = send_initialize(session)
+
+      assert result["instructions"] ==
+               "Use this server to look up user accounts. Always confirm before deleting."
+    end
+
+    test "server_instructions/0 returns the configured value" do
+      assert InstructionsViaOptionServer.server_instructions() ==
+               "Use this server to look up user accounts. Always confirm before deleting."
+    end
+  end
+
+  describe "instructions via callback override" do
+    test "initialize response includes instructions from callback" do
+      {session, _transport} = start_session(InstructionsViaCallbackServer)
+
+      result = send_initialize(session)
+
+      assert result["instructions"] == "Dynamic instructions from callback"
+    end
+
+    test "server_instructions/0 returns the callback value" do
+      assert InstructionsViaCallbackServer.server_instructions() ==
+               "Dynamic instructions from callback"
+    end
+  end
+
+  describe "no instructions" do
+    test "initialize response omits instructions field" do
+      {session, _transport} = start_session(NoInstructionsServer)
+
+      result = send_initialize(session)
+
+      refute Map.has_key?(result, "instructions")
+    end
+
+    test "server_instructions/0 returns nil" do
+      assert NoInstructionsServer.server_instructions() == nil
+    end
+  end
+
+  # Helpers
+
+  defp start_session(server_module) do
+    session_id = "test-#{System.unique_integer([:positive])}"
+    transport_name = Registry.transport_name(server_module, StubTransport)
+    transport = start_supervised!({StubTransport, name: transport_name}, id: transport_name)
+
+    task_sup = Registry.task_supervisor_name(server_module)
+    start_supervised!({Task.Supervisor, name: task_sup}, id: task_sup)
+
+    session_name = Registry.session_name(server_module, session_id)
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: session_id,
+         server_module: server_module,
+         name: session_name,
+         transport: [layer: StubTransport, name: transport_name],
+         task_supervisor: task_sup},
+        id: session_name
+      )
+
+    {session, transport}
+  end
+
+  defp send_initialize(session) do
+    request = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+    {:ok, response_json} = GenServer.call(session, {:mcp_request, request, %{}})
+    response = JSON.decode!(response_json)
+    response["result"]
+  end
+end


### PR DESCRIPTION
## Summary

Adds support for the optional `instructions` field in the MCP initialize response, as defined in the [spec](https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization):

> The server MAY include an `instructions` field containing human-readable instructions for the client. This can be used by clients to improve the LLM's understanding of available tools, resources, etc. It can be thought of like a "hint" to the model. For example, this information MAY be added to the system prompt.

### API

**Via `use` macro option:**
```elixir
use Anubis.Server,
  name: "my-server",
  version: "1.0.0",
  capabilities: [:tools],
  instructions: "Guidelines for using this server..."
```

**Via callback override (for dynamic instructions):**
```elixir
@impl Anubis.Server
def server_instructions do
  "Dynamic instructions based on config..."
end
```

When instructions are `nil` (the default), the field is omitted from the initialize response entirely.

### Changes

- **`lib/anubis/server.ex`** — Added `server_instructions/0` callback (optional, defaults to `nil` or the `:instructions` option), following the same pattern as `server_info/0` and `server_capabilities/0`
- **`lib/anubis/server/session.ex`** — Include `instructions` in the initialize response when non-nil
- **`test/anubis/server/session_instructions_test.exs`** — Tests for both API styles and the nil/omission case

### Test plan

- [x] `mix test` — 650 tests, 0 failures
- [x] `mix format --check-formatted` — clean
- [x] `mix credo` — no issues

Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Servers can expose optional startup instructions that are included in initialization responses when present.
  * Instructions may be supplied via server configuration or provided dynamically by the server implementation.
  * When no instructions are provided, the initialization response omits the instructions field.

* **Tests**
  * Added tests covering configured instructions, dynamic callback-provided instructions, and omission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->