### PR TITLE
Return HTTP 404 instead of 400 for unknown/expired sessions

### DIFF
--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -169,7 +169,7 @@ if Code.ensure_loaded?(Plug) do
           |> send_resp(202, "{}")
 
         {:error, :not_found} ->
-          send_error(conn, 400, "No active session")
+          send_error(conn, 404, "Session not found")
       end
     end
 
@@ -183,7 +183,7 @@ if Code.ensure_loaded?(Plug) do
           |> send_resp(202, "{}")
 
         {:error, :not_found} ->
-          send_error(conn, 400, "No active session")
+          send_error(conn, 404, "Session not found")
       end
     end
 
@@ -197,7 +197,7 @@ if Code.ensure_loaded?(Plug) do
           end
 
         {:error, :no_session} ->
-          send_error(conn, 400, "No active session")
+          send_error(conn, 404, "Session not found")
 
         {:error, reason} ->
           send_jsonrpc_error(
@@ -465,6 +465,7 @@ if Code.ensure_loaded?(Plug) do
 
       mcp_error =
         case status do
+          404 -> Error.protocol(:invalid_request, data)
           405 -> Error.protocol(:method_not_found, data)
           406 -> Error.protocol(:invalid_request, data)
           _ -> Error.protocol(:internal_error, data)

--- a/test/anubis/server/transport/streamable_http/plug_test.exs
+++ b/test/anubis/server/transport/streamable_http/plug_test.exs
@@ -385,7 +385,7 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
       assert conn.status == 202
     end
 
-    test "notification to unknown session returns 400", %{opts: opts} do
+    test "notification to unknown session returns 404", %{opts: opts} do
       notification =
         build_notification("notifications/message", %{
           "level" => "info",
@@ -402,7 +402,7 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
         |> put_req_header("mcp-session-id", "unknown-session")
         |> StreamableHTTPPlug.call(opts)
 
-      assert conn.status == 400
+      assert conn.status == 404
     end
 
     test "initialize request creates new session", %{opts: opts} do


### PR DESCRIPTION
## Summary

- Return HTTP 404 (not 400) when a request references an unknown or expired session ID
- The [MCP Streamable HTTP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) requires 404 for unknown sessions so clients can auto-reconnect
- Affected: `handle_notification_message`, `handle_response_message`, `handle_request_message`

## Problem

After a server restart, clients send requests with stale session IDs. The server returns 400 "No active session", which clients treat as a generic error. MCP clients (e.g., Claude Code) expect 404 to trigger automatic re-initialization.

Fixes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing sessions now return HTTP 404 with "Session not found" instead of HTTP 400.
  * Expanded error-to-protocol mapping so 404 responses are translated into the standardized error protocol for invalid requests.

* **Tests**
  * Updated tests to expect 404 for operations targeting unknown sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->