### PR TITLE
Auto-reinitialize expired sessions for non-initialize requests

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -91,6 +91,24 @@ defmodule Anubis.Server.Session do
     GenServer.start_link(__MODULE__, Map.new(opts), name: name)
   end
 
+  @doc """
+  Auto-initializes a session without a client initialize handshake.
+
+  This is used when a client sends a non-initialize request to an expired or
+  unknown session. Instead of returning 404, the server can create a new session
+  and auto-initialize it so the request can be processed transparently.
+
+  Uses the server's latest supported protocol version and synthetic client info
+  (`%{"name" => "auto-recovered", "version" => "unknown"}`). Server implementations
+  should not rely on this identity for client-specific decisions.
+  """
+  @spec auto_initialize(GenServer.server()) :: :ok | {:error, term()}
+  def auto_initialize(session) do
+    GenServer.call(session, :auto_initialize)
+  catch
+    :exit, reason -> {:error, {:session_unavailable, reason}}
+  end
+
   # Lifecycle
 
   @impl GenServer
@@ -153,6 +171,38 @@ defmodule Anubis.Server.Session do
     state = reset_session_expiry(state)
 
     handle_single_request(decoded, transport_context, state)
+  end
+
+  def handle_call(:auto_initialize, _from, %{initialized: true} = state) do
+    {:reply, :ok, state}
+  end
+
+  def handle_call(:auto_initialize, _from, %{server_module: module} = state) do
+    with [latest_version | _] <- state.supported_versions,
+         {:ok, protocol_version, protocol_module} <-
+           Anubis.Protocol.Registry.negotiate(latest_version, state.supported_versions),
+         auto_state = %{
+           state
+           | protocol_version: protocol_version,
+             protocol_module: protocol_module,
+             client_info: %{"name" => "auto-recovered", "version" => "unknown"},
+             client_capabilities: %{},
+             initialized: true
+         },
+         frame = prepare_frame(auto_state),
+         {:ok, frame} <- maybe_call_init(module, auto_state.client_info, frame) do
+      Logging.server_event("session_auto_initialized", %{
+        session_id: auto_state.session_id,
+        protocol_version: protocol_version
+      })
+
+      maybe_persist_session(%{auto_state | frame: frame})
+      {:reply, :ok, %{auto_state | frame: frame}}
+    else
+      [] -> {:reply, {:error, :no_supported_versions}, state}
+      :error -> {:reply, {:error, :negotiate_failed}, state}
+      {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
+    end
   end
 
   def handle_call(request, from, %{server_module: module} = state) do
@@ -955,6 +1005,16 @@ defmodule Anubis.Server.Session do
   end
 
   # Session persistence
+
+  defp maybe_call_init(module, client_info, frame) do
+    if Anubis.exported?(module, :init, 2) do
+      module.init(client_info, frame)
+    else
+      {:ok, frame}
+    end
+  rescue
+    e -> {:error, e}
+  end
 
   defp maybe_persist_session(%{session_id: session_id} = state) do
     if store = Anubis.get_session_store_adapter() do

--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -38,6 +38,7 @@ if Code.ensure_loaded?(Plug) do
     alias Anubis.MCP.ID
     alias Anubis.MCP.Message
     alias Anubis.Server.Registry
+    alias Anubis.Server.Session
     alias Anubis.Server.Supervisor, as: ServerSupervisor
     alias Anubis.Server.Transport.StreamableHTTP
     alias Anubis.SSE.Streaming
@@ -169,7 +170,7 @@ if Code.ensure_loaded?(Plug) do
           |> send_resp(202, "{}")
 
         {:error, :not_found} ->
-          send_error(conn, 400, "No active session")
+          send_error(conn, 404, "Session not found")
       end
     end
 
@@ -183,7 +184,7 @@ if Code.ensure_loaded?(Plug) do
           |> send_resp(202, "{}")
 
         {:error, :not_found} ->
-          send_error(conn, 400, "No active session")
+          send_error(conn, 404, "Session not found")
       end
     end
 
@@ -195,9 +196,6 @@ if Code.ensure_loaded?(Plug) do
           else
             handle_json_request(conn, session_pid, message, session_id, context, opts)
           end
-
-        {:error, :no_session} ->
-          send_error(conn, 400, "No active session")
 
         {:error, reason} ->
           send_jsonrpc_error(
@@ -343,7 +341,33 @@ if Code.ensure_loaded?(Plug) do
           start_new_session(opts, session_id)
 
         {:error, :not_found} ->
-          {:error, :no_session}
+          start_and_auto_initialize_session(opts, session_id)
+      end
+    end
+
+    defp start_and_auto_initialize_session(opts, session_id) do
+      case start_new_session(opts, session_id) do
+        {:ok, pid} ->
+          case Session.auto_initialize(pid) do
+            :ok ->
+              Logging.transport_event("session_auto_reinitialized", %{
+                session_id: session_id
+              })
+
+              {:ok, pid}
+
+            {:error, reason} ->
+              Logging.transport_event("session_auto_reinitialize_failed", %{
+                session_id: session_id,
+                reason: inspect(reason)
+              })
+
+              stop_session_process(opts, session_id)
+              {:error, reason}
+          end
+
+        error ->
+          error
       end
     end
 
@@ -465,6 +489,7 @@ if Code.ensure_loaded?(Plug) do
 
       mcp_error =
         case status do
+          404 -> Error.protocol(:invalid_request, data)
           405 -> Error.protocol(:method_not_found, data)
           406 -> Error.protocol(:invalid_request, data)
           _ -> Error.protocol(:internal_error, data)

--- a/test/anubis/server/transport/streamable_http/plug_test.exs
+++ b/test/anubis/server/transport/streamable_http/plug_test.exs
@@ -385,7 +385,7 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
       assert conn.status == 202
     end
 
-    test "notification to unknown session returns 400", %{opts: opts} do
+    test "notification to unknown session returns 404", %{opts: opts} do
       notification =
         build_notification("notifications/message", %{
           "level" => "info",
@@ -402,7 +402,25 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
         |> put_req_header("mcp-session-id", "unknown-session")
         |> StreamableHTTPPlug.call(opts)
 
-      assert conn.status == 400
+      assert conn.status == 404
+    end
+
+    test "request to unknown session auto-reinitializes", %{opts: opts} do
+      request = build_request("tools/list", %{})
+      {:ok, body} = Message.encode_request(request, 42)
+
+      conn =
+        :post
+        |> conn("/", body)
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("accept", "application/json")
+        |> put_req_header("mcp-session-id", "expired-session-id")
+        |> StreamableHTTPPlug.call(opts)
+
+      assert conn.status == 200
+      {:ok, response} = Jason.decode(conn.resp_body)
+      assert is_map(response["result"])
+      assert Map.has_key?(response["result"], "tools")
     end
 
     test "initialize request creates new session", %{opts: opts} do


### PR DESCRIPTION
## Summary
- Returns HTTP 404 instead of 400 for unknown/expired sessions (supersedes #124)
- Auto-creates and initializes a new session when a request arrives with an unknown/expired session ID
- Adds `Session.auto_initialize/1` that programmatically initializes a session without client handshake

## Motivation
MCP clients like Claude Code cache session IDs but don't recover gracefully when sessions expire server-side. When a stale session ID is sent, the client gets an error and stops working until manually restarted.

This fix makes the server transparently recover by creating and initializing a new session on-the-fly, so the client's request succeeds without requiring re-initialization.

Related issues:
- anthropics/claude-code#9608
- anthropics/claude-code#27142
- anthropics/claude-code#17412

Supersedes #124 (which only fixed the HTTP status code but didn't solve the underlying recovery problem).

## Test plan
- [x] All 634 existing tests pass
- [x] New test: "request to unknown session auto-reinitializes" — sends `tools/list` with expired session ID, asserts 200 response
- [x] Tested in production with Claude Code — confirmed sessions auto-recover after expiration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic session recovery API that transparently reinitializes sessions when unavailable.

* **Bug Fixes**
  * Improved HTTP responses for missing sessions: 404 with clearer "Session not found" messaging.
  * When a request arrives for a missing session, the server now attempts to start and auto-recover a session and logs failures.

* **Tests**
  * Updated tests to expect 404 for missing-session notifications and added a request case verifying tool-list after recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->