### PR TITLE
fix: buffer chunked STDIO responses before decoding in client

### DIFF
--- a/lib/anubis.ex
+++ b/lib/anubis.ex
@@ -16,7 +16,8 @@ defmodule Anubis do
                          ClientSSE,
                          ClientStreamableHTTP,
                          StubTransport,
-                         Anubis.MockTransport
+                         Anubis.MockTransport,
+                         BufferedMockTransport
                        ],
                        else: [ClientSTDIO, ClientSSE, ClientStreamableHTTP]
 

--- a/lib/anubis/client.ex
+++ b/lib/anubis/client.ex
@@ -916,14 +916,22 @@ defmodule Anubis.Client do
     protocol_version = opts.protocol_version
     transport = %{layer: layer, name: name}
 
+    transport_parse_state =
+      if function_exported?(layer, :transport_init, 1) do
+        {:ok, ps} = layer.transport_init()
+        ps
+      end
+
     state =
-      State.new(%{
+      %{
         client_info: opts.client_info,
         capabilities: opts.capabilities,
         protocol_version: protocol_version,
         transport: transport,
         timeout: opts.timeout
-      })
+      }
+      |> State.new()
+      |> Map.put(:transport_parse_state, transport_parse_state)
 
     client_name = get_in(opts, [:client_info, "name"])
 
@@ -1139,9 +1147,14 @@ defmodule Anubis.Client do
 
   @impl true
   def handle_cast({:response, response_data}, state) do
-    case Message.decode(response_data) do
-      {:ok, [message]} ->
-        {:noreply, handle_message(message, state)}
+    case parse_response(response_data, state) do
+      {:ok, messages, state} ->
+        state =
+          Enum.reduce(messages, state, fn message, acc ->
+            handle_message(message, acc)
+          end)
+
+        {:noreply, state}
 
       {:error, error} ->
         Logging.client_event("decode_failed", %{error: error}, level: :warning)
@@ -1153,6 +1166,23 @@ defmodule Anubis.Client do
       Logging.client_event("response_handling_failed", %{error: err}, level: :error)
 
       {:noreply, state}
+  end
+
+  defp parse_response(data, %{transport_parse_state: nil} = state) do
+    case Message.decode(data) do
+      {:ok, messages} -> {:ok, messages, state}
+      {:error, _} = error -> error
+    end
+  end
+
+  defp parse_response(data, %{transport: %{layer: layer}} = state) do
+    case layer.parse(data, state.transport_parse_state) do
+      {:ok, messages, new_parse_state} ->
+        {:ok, messages, %{state | transport_parse_state: new_parse_state}}
+
+      {:error, _} = error ->
+        error
+    end
   end
 
   # Server request handling

--- a/lib/anubis/client/state.ex
+++ b/lib/anubis/client/state.ex
@@ -37,7 +37,8 @@ defmodule Anubis.Client.State do
     log_callback: nil,
     sampling_callback: nil,
     roots: %{},
-    ready_waiters: []
+    ready_waiters: [],
+    transport_parse_state: nil
   ]
 
   @spec new(map()) :: t()

--- a/test/anubis/client_test.exs
+++ b/test/anubis/client_test.exs
@@ -1719,4 +1719,69 @@ defmodule Anubis.ClientTest do
       assert catch_exit(Anubis.Client.await_ready(client, timeout: 100))
     end
   end
+
+  describe "chunked STDIO response buffering" do
+    test "handles response split across multiple port data messages" do
+      client =
+        start_supervised!(%{
+          id: Anubis.Client,
+          start:
+            {Anubis.Client, :start_link_server,
+             [
+               [
+                 transport: [layer: BufferedMockTransport, name: BufferedMockTransport],
+                 client_info: %{"name" => "TestClient", "version" => "1.0.0"},
+                 capabilities: %{}
+               ]
+             ]},
+          restart: :temporary
+        })
+
+      initialize_client(client)
+
+      # Start list_tools which registers a pending request
+      task =
+        Task.async(fn ->
+          Anubis.Client.list_tools(client, timeout: 5_000)
+        end)
+
+      Process.sleep(50)
+
+      # Get the actual request ID that the client generated
+      request_id = get_request_id(client, "tools/list")
+      assert request_id
+
+      # Build the response with the correct request ID
+      response_json =
+        JSON.encode!(%{
+          "jsonrpc" => "2.0",
+          "id" => request_id,
+          "result" => %{
+            "tools" => [
+              %{
+                "name" => "search",
+                "description" => "Search for things",
+                "inputSchema" => %{"type" => "object"}
+              }
+            ]
+          }
+        })
+
+      full_message = response_json <> "\n"
+
+      # Split in the middle to simulate chunked port delivery
+      split_point = div(byte_size(full_message), 2)
+      <<chunk1::binary-size(split_point), chunk2::binary>> = full_message
+
+      # Send chunks separately — first chunk has no newline, so it should buffer
+      GenServer.cast(client, {:response, chunk1})
+      Process.sleep(20)
+
+      # Second chunk completes the line — now it should decode and reply
+      GenServer.cast(client, {:response, chunk2})
+
+      assert {:ok, %Response{result: %{"tools" => [%{"name" => "search"}]}}} =
+               Task.await(task, 2_000)
+    end
+  end
 end

--- a/test/support/buffered_mock_transport.ex
+++ b/test/support/buffered_mock_transport.ex
@@ -1,0 +1,27 @@
+defmodule BufferedMockTransport do
+  @moduledoc """
+  A mock transport that delegates parse/encode to STDIO (for buffering)
+  but stubs the GenServer behaviour. Used to test chunked STDIO responses.
+  """
+  @behaviour Anubis.Transport
+  @behaviour Anubis.Transport.Behaviour
+
+  alias Anubis.Transport.STDIO
+
+  defdelegate transport_init(opts \\ []), to: STDIO
+  defdelegate parse(raw, state), to: STDIO
+  defdelegate encode(message, state), to: STDIO
+  defdelegate extract_metadata(raw, state), to: STDIO
+
+  @impl Anubis.Transport.Behaviour
+  def start_link(_opts), do: {:ok, self()}
+
+  @impl Anubis.Transport.Behaviour
+  def send_message(_, _, _opts \\ [timeout: 1_000]), do: :ok
+
+  @impl Anubis.Transport.Behaviour
+  def shutdown(_), do: :ok
+
+  @impl Anubis.Transport.Behaviour
+  def supported_protocol_versions, do: :all
+end


### PR DESCRIPTION
## Problem

The client was calling Message.decode on each raw port data message independently. When a large JSON response (e.g., Grafana's 50+ tools) arrives in multiple port data chunks, each partial chunk fails to parse.

## Solution

Fix by using the transport's parse/2 function (which buffers by newline) instead of Message.decode for transports that implement it. Falls back to Message.decode for transports without parse support (e.g., mocks).

## Rationale

I have an MCP client using Anubis that failed to connect to my Grafana MCP server via its stdio protocol. The issue was the large number of tools provided by the Grafana MCP server which arrive in separate data chunks. The underlying issue was identified and fixed by Claude Opus 4.6, and I confirmed that this is working both for regular small MCP responses but also these bigger chunked ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced response parsing to properly handle JSON-RPC messages received incrementally across multiple transmission chunks, improving resilience when responses arrive fragmented.

* **Tests**
  * Added test coverage for chunked and buffered response scenarios to ensure message assembly works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->