### PR TITLE
fix: correct SSE task lifecycle bugs in StreamableHTTP transport

### DIFF
--- a/lib/anubis/transport/streamable_http.ex
+++ b/lib/anubis/transport/streamable_http.ex
@@ -246,7 +246,7 @@ defmodule Anubis.Transport.StreamableHTTP do
   @impl GenServer
   def handle_cast(:close_connection, state) do
     if state.session_id, do: delete_session(state)
-    if state.sse_task, do: Task.shutdown(state.sse_task, :brutal_kill)
+    if state.sse_task, do: Process.exit(state.sse_task, :kill)
 
     {:stop, :normal, state}
   end
@@ -278,7 +278,7 @@ defmodule Anubis.Transport.StreamableHTTP do
 
   @impl GenServer
   def handle_info({:DOWN, _ref, :process, pid, reason}, state) when state.sse_task != nil do
-    if pid == state.sse_task.pid do
+    if pid == state.sse_task do
       Logging.transport_event("sse_task_down", %{reason: reason})
       new_state = maybe_start_sse_connection(%{state | sse_task: nil})
       {:noreply, new_state}
@@ -295,7 +295,7 @@ defmodule Anubis.Transport.StreamableHTTP do
 
   @impl GenServer
   def terminate(reason, state) do
-    if state.sse_task, do: Task.shutdown(state.sse_task, 5000)
+    if state.sse_task, do: Process.exit(state.sse_task, :kill)
     if state.session_id, do: delete_session(state)
 
     emit_telemetry(:terminate, state, %{reason: reason})
@@ -351,7 +351,10 @@ defmodule Anubis.Transport.StreamableHTTP do
   end
 
   defp handle_response(%{headers: headers, body: body, status: status}, state) do
-    new_state = update_session_id(state, headers)
+    new_state =
+      state
+      |> update_session_id(headers)
+      |> maybe_start_sse_on_session_acquired(state)
 
     Logging.transport_event("http_response", %{
       status: status,
@@ -482,14 +485,27 @@ defmodule Anubis.Transport.StreamableHTTP do
 
   defp maybe_start_sse_connection(%{enable_sse: true, session_id: nil} = state), do: state
 
+  defp maybe_start_sse_connection(%{enable_sse: true, sse_task: task} = state) when not is_nil(task),
+    do: state
+
   defp maybe_start_sse_connection(%{enable_sse: true} = state) do
-    task = start_sse_task(state)
-    %{state | sse_task: task}
+    pid = start_sse_task(state)
+    %{state | sse_task: pid}
   end
+
+  defp maybe_start_sse_on_session_acquired(%{session_id: nil} = new_state, _old_state), do: new_state
+
+  defp maybe_start_sse_on_session_acquired(new_state, %{session_id: nil}) do
+    maybe_start_sse_connection(new_state)
+  end
+
+  defp maybe_start_sse_on_session_acquired(new_state, _old_state), do: new_state
 
   defp start_sse_task(state) do
     parent = self()
-    Task.start_link(fn -> run_sse_task(parent, state) end)
+    {:ok, pid} = Task.start(fn -> run_sse_task(parent, state) end)
+    Process.monitor(pid)
+    pid
   end
 
   defp run_sse_task(parent, state) do

--- a/lib/anubis/transport/streamable_http.ex
+++ b/lib/anubis/transport/streamable_http.ex
@@ -306,11 +306,12 @@ defmodule Anubis.Transport.StreamableHTTP do
   defp send_http_request(state, message, timeout) do
     # Only advertise SSE support if enabled AND we have a session
     # This prevents trying to route responses through SSE before it's established
-    accept_header = if state.enable_sse && state.session_id do
-      "application/json, text/event-stream"
-    else
-      "application/json"
-    end
+    accept_header =
+      if state.enable_sse && state.session_id do
+        "application/json, text/event-stream"
+      else
+        "application/json"
+      end
 
     headers =
       state.headers
@@ -485,8 +486,7 @@ defmodule Anubis.Transport.StreamableHTTP do
 
   defp maybe_start_sse_connection(%{enable_sse: true, session_id: nil} = state), do: state
 
-  defp maybe_start_sse_connection(%{enable_sse: true, sse_task: task} = state) when not is_nil(task),
-    do: state
+  defp maybe_start_sse_connection(%{enable_sse: true, sse_task: task} = state) when not is_nil(task), do: state
 
   defp maybe_start_sse_connection(%{enable_sse: true} = state) do
     pid = start_sse_task(state)

--- a/test/anubis/transport/streamable_http_test.exs
+++ b/test/anubis/transport/streamable_http_test.exs
@@ -594,6 +594,11 @@ defmodule Anubis.Transport.StreamableHTTPTest do
         end
       end)
 
+      # Handle SSE GET connection attempt after session is acquired
+      Bypass.stub(bypass, "GET", "/mcp", fn conn ->
+        Plug.Conn.resp(conn, 405, "")
+      end)
+
       # Handle DELETE request during shutdown
       Bypass.stub(bypass, "DELETE", "/mcp", fn conn ->
         Plug.Conn.resp(conn, 200, "")


### PR DESCRIPTION
## Context

While reviewing PR #121 (fix/streamable-http-accept-header-120, now merged), three additional bugs were identified in the `enable_sse` code path of `Anubis.Transport.StreamableHTTP`. This PR fixes all three.

## What was wrong

### Bug 1 — SSE GET connection never started after session acquisition
`maybe_start_sse_connection/1` was only called from `handle_continue(:connect)`, before the session existed, making it a no-op. Once the session was acquired on the first response, subsequent requests correctly advertised `text/event-stream` (as fixed by #121), but no actual SSE GET stream had been opened — reproducing the same timeout on the second request.

**Fix:** `maybe_start_sse_on_session_acquired/2` is now called inside `handle_response` and fires the SSE GET connection exactly once, on the `nil → session_id` transition.

### Bug 2 — `Task.start_link/1` stores `{:ok, pid}`, not `%Task{}` — crashes on shutdown
`start_sse_task/1` called `Task.start_link/1`, which returns `{:ok, pid}`. That tuple was stored as `state.sse_task`, then passed to `Task.shutdown/2` (expects `%Task{}`) and accessed as `state.sse_task.pid` (dot access on a tuple raises `BadMapError`). Both `terminate/2`, `handle_cast(:close_connection)`, and the `{:DOWN, ...}` handler would crash whenever an SSE task was active.

**Fix:** Changed to `Task.start/1` with explicit `{:ok, pid}` extraction. All call sites now use `Process.exit(state.sse_task, :kill)` and `pid == state.sse_task`.

### Bug 3 — SSE task linked to GenServer causes cascading crash
`Task.start_link` linked the SSE task to the transport GenServer. Any network error in the SSE stream would propagate and kill the transport, despite the `{:DOWN, ...}` handler intended to catch this.

**Fix:** `Task.start/1` (unlinked) + `Process.monitor/1` — the GenServer receives `{:DOWN, ...}` for graceful restart without being killed by the SSE task's failure.
