### PR TITLE
fix: prevent lost SSE responses when client connection closes

### DIFF
--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -266,11 +266,21 @@ if Code.ensure_loaded?(Plug) do
 
       cond do
         handler_pid && Process.alive?(handler_pid) ->
-          send(handler_pid, {:sse_message, response})
+          ref = make_ref()
+          send(handler_pid, {:sse_message, response, {self(), ref}})
 
-          conn
-          |> put_resp_content_type("application/json")
-          |> send_resp(202, "{}")
+          receive do
+            {^ref, :ok} ->
+              conn
+              |> put_resp_content_type("application/json")
+              |> send_resp(202, "{}")
+
+            {^ref, {:error, _reason}} ->
+              establish_sse_for_request(conn, response, session_id, opts)
+          after
+            5_000 ->
+              establish_sse_for_request(conn, response, session_id, opts)
+          end
 
         handler_pid ->
           StreamableHTTP.unregister_sse_handler(transport, session_id, handler_pid)

--- a/lib/anubis/sse/streaming.ex
+++ b/lib/anubis/sse/streaming.ex
@@ -97,13 +97,27 @@ if Code.ensure_loaded?(Plug) do
             {:error, reason} ->
               Logging.transport_event(
                 "sse_send_failed",
-                %{
-                  session_id: session_id,
-                  reason: reason
-                },
-                level: :error
+                %{session_id: session_id, reason: reason},
+                level: :warning
               )
 
+              conn
+          end
+
+        {:sse_message, message, {from, ref}} when is_binary(message) ->
+          case send_event(conn, message, event_counter) do
+            {:ok, conn} ->
+              send(from, {ref, :ok})
+              loop(conn, transport, session_id, event_counter + 1)
+
+            {:error, reason} ->
+              Logging.transport_event(
+                "sse_send_failed",
+                %{session_id: session_id, reason: reason},
+                level: :warning
+              )
+
+              send(from, {ref, {:error, reason}})
               conn
           end
 


### PR DESCRIPTION
## Problem

When using the Streamable HTTP transport with SSE responses, tool responses could be silently dropped, leaving clients hanging indefinitely. The sequence:

1. Client POSTs a request with `Accept: text/event-stream`
2. Server processes the request and gets a response
3. Server checks `Process.alive?(handler_pid)` → `true`
4. Server calls `send(handler_pid, {:sse_message, response})` — fire-and-forget
5. Server returns `202 Accepted` to the client immediately
6. SSE handler tries `Plug.Conn.chunk/2` — connection already closed → `{:error, :closed}`
7. Error logged as `sse_send_failed`
8. **Client received 202 but the response never arrives — hangs forever**

Closes #81.

## Solution

Replace the fire-and-forget `send/2` in `route_sse_response` with a synchronous delivery pattern. The plug sends `{:sse_message, response, {self(), ref}}` and waits for a confirmation from the SSE streaming loop:

- **`:ok`** → the chunk was written successfully, return `202 Accepted`  
- **`{:error, _reason}`** → the connection is closed, fall back to `establish_sse_for_request/4` which opens an inline SSE stream on the current HTTP connection and delivers the response directly  
- **5 s timeout** → same fallback as the error case

`Streaming.loop` gains a matching clause for `{:sse_message, msg, {from, ref}}` that sends `{ref, :ok | {:error, reason}}` after `Plug.Conn.chunk/2` resolves. The existing `{:sse_message, msg}` clause is preserved for broadcast notifications and keepalives that do not need confirmation.

## Rationale

The Cowboy handler process running `route_sse_response` is a plain process (not a GenServer), so blocking in a `receive` is safe and the natural fit here. Making the SSE delivery synchronous is the minimal change that eliminates the race without restructuring the transport architecture.

The `sse_send_failed` log level is also downgraded from `:error` to `:warning` — a closed client connection is a normal operational event, not an application error.