### PR TITLE
feat: pluggable session supervisor and :via tuple session naming

### DIFF
--- a/lib/anubis/server/registry.ex
+++ b/lib/anubis/server/registry.ex
@@ -21,6 +21,41 @@ defmodule Anubis.Server.Registry do
   @callback lookup_session(name :: term(), session_id()) :: {:ok, pid()} | {:error, :not_found}
   @callback unregister_session(name :: term(), session_id()) :: :ok
 
+  @doc """
+  Returns the GenServer name for a session. Override this to return a `:via` tuple
+  (e.g. `{:via, Horde.Registry, {name, session_id}}`) when using a distributed registry
+  that auto-registers processes on `start_link`. The default returns a plain atom.
+
+  When a `:via` tuple is returned, `register_session/3` should be a no-op since
+  registration happens automatically on process start.
+  """
+  @callback session_name(registry_name :: term(), session_id()) :: GenServer.name()
+
+  @optional_callbacks session_name: 2
+
+  @doc """
+  Resolves the session GenServer name via the registry adapter.
+
+  Falls back to the default atom-based naming if the adapter does not implement
+  the optional `session_name/2` callback.
+  """
+  @spec resolve_session_name(module(), term(), session_id()) :: GenServer.name()
+  def resolve_session_name(registry_mod, registry_name, session_id) do
+    if function_exported?(registry_mod, :session_name, 2) do
+      registry_mod.session_name(registry_name, session_id)
+    else
+      session_name_from_registry_name(registry_name, session_id)
+    end
+  end
+
+  defp session_name_from_registry_name(registry_name, session_id) when is_atom(registry_name) do
+    :"#{registry_name}.session.#{session_id}"
+  end
+
+  defp session_name_from_registry_name(_registry_name, session_id) do
+    :"Anubis.session.#{session_id}"
+  end
+
   # Deterministic atom naming for internal processes
 
   @spec transport_name(module(), atom()) :: atom()

--- a/lib/anubis/server/registry/local.ex
+++ b/lib/anubis/server/registry/local.ex
@@ -28,6 +28,9 @@ defmodule Anubis.Server.Registry.Local do
   end
 
   @impl Anubis.Server.Registry
+  def session_name(registry_name, session_id), do: :"#{registry_name}.session.#{session_id}"
+
+  @impl Anubis.Server.Registry
   def register_session(name, session_id, pid) do
     GenServer.call(name, {:register, session_id, pid})
   end

--- a/lib/anubis/server/registry/none.ex
+++ b/lib/anubis/server/registry/none.ex
@@ -11,6 +11,9 @@ defmodule Anubis.Server.Registry.None do
   def child_spec(_opts), do: :ignore
 
   @impl Anubis.Server.Registry
+  def session_name(_registry_name, session_id), do: :"Anubis.stdio.session.#{session_id}"
+
+  @impl Anubis.Server.Registry
   def register_session(_name, _session_id, _pid), do: :ok
 
   @impl Anubis.Server.Registry

--- a/lib/anubis/server/supervisor.ex
+++ b/lib/anubis/server/supervisor.ex
@@ -19,6 +19,7 @@ defmodule Anubis.Server.Supervisor do
           {:transport, transport}
           | {:name, Supervisor.name()}
           | {:registry, {module(), keyword()}}
+          | {:supervisor, {module(), keyword()}}
           | {:session_idle_timeout, pos_integer() | nil}
           | {:request_timeout, pos_integer() | nil}
 
@@ -32,6 +33,7 @@ defmodule Anubis.Server.Supervisor do
       * `:transport` - Transport configuration (required)
       * `:name` - Supervisor name (optional, defaults to atom name)
       * `:registry` - `{module, opts}` for custom registry (auto-selected by default)
+      * `:supervisor` - `{module, opts}` for custom session supervisor (defaults to `{DynamicSupervisor, []}`)
       * `:session_idle_timeout` - Time in milliseconds before idle sessions expire (default: 30 minutes)
       * `:request_timeout` - Time limit in milliseconds for server requests (defaults to 30s)
   """
@@ -43,12 +45,13 @@ defmodule Anubis.Server.Supervisor do
   end
 
   @doc """
-  Starts a new session under the DynamicSupervisor.
+  Starts a new session under the configured session supervisor.
   """
   @spec start_session(module(), keyword()) :: DynamicSupervisor.on_start_child()
   def start_session(server, opts) do
     sup_name = Registry.session_supervisor_name(server)
-    DynamicSupervisor.start_child(sup_name, {Session, opts})
+    sup_mod = get_session_supervisor_mod(server)
+    sup_mod.start_child(sup_name, {Session, opts})
   end
 
   @doc """
@@ -61,7 +64,8 @@ defmodule Anubis.Server.Supervisor do
     case registry_mod.lookup_session(registry_name, session_id) do
       {:ok, pid} ->
         sup_name = Registry.session_supervisor_name(server)
-        DynamicSupervisor.terminate_child(sup_name, pid)
+        sup_mod = get_session_supervisor_mod(server)
+        sup_mod.terminate_child(sup_name, pid)
 
       {:error, :not_found} ->
         {:error, :not_found}
@@ -79,6 +83,9 @@ defmodule Anubis.Server.Supervisor do
       task_supervisor = Registry.task_supervisor_name(server)
 
       {registry_mod, registry_opts} = resolve_registry(opts, transport, server)
+      {sup_mod, _sup_opts} = resolve_session_supervisor(opts)
+
+      :persistent_term.put({__MODULE__, server, :session_supervisor_mod}, sup_mod)
 
       {layer, transport_opts} = parse_transport_child(transport, server)
 
@@ -107,7 +114,7 @@ defmodule Anubis.Server.Supervisor do
             build_stdio_children(server, layer, transport_opts, task_supervisor, session_config)
 
           _ ->
-            build_http_children(server, registry_mod, registry_opts, layer, transport_opts, task_supervisor)
+            build_http_children(server, registry_mod, registry_opts, sup_mod, layer, transport_opts, task_supervisor)
         end
 
       Supervisor.init(children, strategy: :one_for_all)
@@ -119,6 +126,18 @@ defmodule Anubis.Server.Supervisor do
   @doc false
   def get_session_config(server) do
     :persistent_term.get({__MODULE__, server, :session_config})
+  end
+
+  @doc false
+  def get_session_supervisor_mod(server) do
+    :persistent_term.get({__MODULE__, server, :session_supervisor_mod}, DynamicSupervisor)
+  end
+
+  defp resolve_session_supervisor(opts) do
+    case Keyword.get(opts, :supervisor) do
+      {mod, sup_opts} -> {mod, sup_opts}
+      nil -> {DynamicSupervisor, []}
+    end
   end
 
   # Auto-select registry: STDIO -> None, HTTP -> Local
@@ -160,8 +179,8 @@ defmodule Anubis.Server.Supervisor do
     ]
   end
 
-  # For HTTP transports: DynamicSupervisor for sessions + registry
-  defp build_http_children(server, registry_mod, registry_opts, layer, transport_opts, task_supervisor) do
+  # For HTTP transports: session supervisor (DynamicSupervisor or pluggable) + registry
+  defp build_http_children(server, registry_mod, registry_opts, sup_mod, layer, transport_opts, task_supervisor) do
     session_sup_name = Registry.session_supervisor_name(server)
 
     registry_child =
@@ -172,7 +191,7 @@ defmodule Anubis.Server.Supervisor do
 
     children = [
       {Task.Supervisor, name: task_supervisor},
-      {DynamicSupervisor, name: session_sup_name, strategy: :one_for_one},
+      {sup_mod, name: session_sup_name, strategy: :one_for_one},
       {layer, transport_opts}
     ]
 

--- a/lib/anubis/server/transport/sse.ex
+++ b/lib/anubis/server/transport/sse.ex
@@ -355,7 +355,7 @@ defmodule Anubis.Server.Transport.SSE do
 
   defp start_new_session(session_id, state) do
     session_config = ServerSupervisor.get_session_config(state.server)
-    session_name = Registry.session_name(state.server, session_id)
+    session_name = Registry.resolve_session_name(state.registry_mod, state.registry_name, session_id)
 
     session_opts = [
       session_id: session_id,

--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -373,7 +373,7 @@ if Code.ensure_loaded?(Plug) do
 
     defp start_new_session(%{server: server, registry_mod: registry_mod, registry_name: registry_name} = opts, session_id) do
       session_config = ServerSupervisor.get_session_config(server)
-      session_name = Registry.session_name(server, session_id)
+      session_name = Registry.resolve_session_name(registry_mod, registry_name, session_id)
 
       session_opts = [
         session_id: session_id,

--- a/lib/anubis/transport/streamable_http.ex
+++ b/lib/anubis/transport/streamable_http.ex
@@ -306,11 +306,12 @@ defmodule Anubis.Transport.StreamableHTTP do
   defp send_http_request(state, message, timeout) do
     # Only advertise SSE support if enabled AND we have a session
     # This prevents trying to route responses through SSE before it's established
-    accept_header = if state.enable_sse && state.session_id do
-      "application/json, text/event-stream"
-    else
-      "application/json"
-    end
+    accept_header =
+      if state.enable_sse && state.session_id do
+        "application/json, text/event-stream"
+      else
+        "application/json"
+      end
 
     headers =
       state.headers


### PR DESCRIPTION
## Problem

`Anubis.Server.Supervisor` hardcoded `DynamicSupervisor` in three places, making it impossible to swap in `Horde.DynamicSupervisor` for distributed deployments. Additionally, `Registry.session_name/2` returned plain atoms, preventing Horde.Registry from auto-registering sessions via `:via` tuples — creating a race condition window between `start_child` and explicit `register_session` calls.

Fixes #113.

## Solution

**Option A — Pluggable session supervisor**

Added a `:supervisor` option to `Anubis.Server.Supervisor.start_link/2`, mirroring the existing `:registry` option:

```elixir
{MyMCPServer,
  transport: {:streamable_http, start: true},
  registry: {Horde.Registry, [name: MyRegistry, keys: :unique, members: :auto]},
  supervisor: {Horde.DynamicSupervisor, [name: MySupervisor, strategy: :one_for_one, members: :auto]}}
```

The resolved module is stored in `persistent_term` and used in `start_session/2` and `stop_session/3`. Defaults to `{DynamicSupervisor, []}` — fully backward compatible.

**Option B1 — `session_name/2` callback on the Registry behaviour**

Added an optional `session_name/2` callback to `Anubis.Server.Registry`:

```elixir
@callback session_name(registry_name :: term(), session_id()) :: GenServer.name()
```

Both `Registry.Local` and `Registry.None` implement it returning atoms (same behaviour as before). A Horde adapter can return `{:via, Horde.Registry, {name, session_id}}`, which causes auto-registration on `GenServer.start_link` — making `register_session/3` a no-op and eliminating the race condition entirely.

`Registry.resolve_session_name/3` is the new call site in both the StreamableHTTP plug and the SSE transport, falling back to atom naming when the adapter doesn't implement the callback.

## Rationale

Followed the existing `:registry` pluggability pattern for `:supervisor` — minimal surface, same mental model. The `session_name/2` callback keeps naming strategy co-located with the registry adapter that owns it, rather than spreading the logic across transports. Making it `@optional_callbacks` preserves backward compatibility for existing custom adapters.