### PR TITLE
fix: handle session expiry gracefully with optional callback and store restore

### DIFF
--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -185,6 +185,26 @@ defmodule Anubis.Server do
   """
   @callback server_instructions() :: String.t() | nil
 
+  @doc """
+  Called when a session is being auto-recovered after expiry.
+
+  Invoked during `auto_initialize/1` instead of the normal client handshake.
+  Receives the session ID and the current frame (pre-populated from the session
+  store if one is configured).
+
+  Return values:
+  - `{:ok, frame}` — accept recovery using synthetic client info
+  - `{:ok, client_info, frame}` — accept recovery and supply real client info
+  - `{:error, reason}` — reject recovery; the client receives an internal error
+
+  If this callback is not implemented, the default behavior is unchanged:
+  synthetic client info is used and `init/2` is called normally.
+  """
+  @callback handle_session_expired(session_id :: String.t(), Frame.t()) ::
+              {:ok, Frame.t()}
+              | {:ok, client_info :: map(), Frame.t()}
+              | {:error, reason :: term()}
+
   @callback handle_info(event :: term, Frame.t()) ::
               {:noreply, Frame.t()}
               | {:noreply, Frame.t(), timeout() | :hibernate | {:continue, arg :: term}}
@@ -238,7 +258,8 @@ defmodule Anubis.Server do
                       handle_sampling: 3,
                       handle_completion: 3,
                       handle_roots: 3,
-                      server_instructions: 0
+                      server_instructions: 0,
+                      handle_session_expired: 2
 
   @doc false
   defguard is_server_capability(capability) when capability in @server_capabilities

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -183,28 +183,45 @@ defmodule Anubis.Server.Session do
   def handle_call(:auto_initialize, _from, %{server_module: module} = state) do
     with [latest_version | _] <- state.supported_versions,
          {:ok, protocol_version, protocol_module} <-
-           Anubis.Protocol.Registry.negotiate(latest_version, state.supported_versions),
-         auto_state = %{
-           state
-           | protocol_version: protocol_version,
-             protocol_module: protocol_module,
-             client_info: %{"name" => "auto-recovered", "version" => "unknown"},
-             client_capabilities: %{},
-             initialized: true
-         },
-         frame = prepare_frame(auto_state),
-         {:ok, frame} <- maybe_call_init(module, auto_state.client_info, frame) do
-      Logging.server_event("session_auto_initialized", %{
-        session_id: auto_state.session_id,
-        protocol_version: protocol_version
-      })
+           Anubis.Protocol.Registry.negotiate(latest_version, state.supported_versions) do
+      {restored_client_info, restored_frame} = maybe_restore_from_store(state.session_id)
 
-      maybe_persist_session(%{auto_state | frame: frame})
-      {:reply, :ok, %{auto_state | frame: frame}}
+      auto_state = %{
+        state
+        | protocol_version: protocol_version,
+          protocol_module: protocol_module,
+          client_info: restored_client_info || %{"name" => "auto-recovered", "version" => "unknown"},
+          client_capabilities: %{},
+          initialized: true,
+          frame: restored_frame || state.frame
+      }
+
+      frame = prepare_frame(auto_state)
+
+      case maybe_call_session_expired(module, auto_state.session_id, frame) do
+        {:ok, frame} ->
+          do_complete_auto_init(auto_state, frame, protocol_version)
+
+        {:ok, client_info, frame} ->
+          do_complete_auto_init(%{auto_state | client_info: client_info}, frame, protocol_version)
+
+        {:error, reason} ->
+          Logging.server_event("session_recovery_rejected", %{
+            session_id: auto_state.session_id,
+            reason: inspect(reason)
+          })
+
+          {:reply, {:error, {:recovery_rejected, reason}}, state}
+
+        :default ->
+          case maybe_call_init(module, auto_state.client_info, frame) do
+            {:ok, frame} -> do_complete_auto_init(auto_state, frame, protocol_version)
+            {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
+          end
+      end
     else
       [] -> {:reply, {:error, :no_supported_versions}, state}
       :error -> {:reply, {:error, :negotiate_failed}, state}
-      {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
     end
   end
 
@@ -1017,6 +1034,44 @@ defmodule Anubis.Server.Session do
     end
   rescue
     e -> {:error, e}
+  end
+
+  defp maybe_call_session_expired(module, session_id, frame) do
+    if Anubis.exported?(module, :handle_session_expired, 2) do
+      module.handle_session_expired(session_id, frame)
+    else
+      :default
+    end
+  rescue
+    e -> {:error, e}
+  end
+
+  defp maybe_restore_from_store(session_id) do
+    case Anubis.get_session_store_adapter() do
+      nil ->
+        {nil, nil}
+
+      store ->
+        case store.load(session_id, []) do
+          {:ok, saved} ->
+            client_info = saved["client_info"] || saved[:client_info]
+            frame = Frame.from_saved(saved["frame"] || saved[:frame] || %{})
+            {client_info, frame}
+
+          _ ->
+            {nil, nil}
+        end
+    end
+  end
+
+  defp do_complete_auto_init(auto_state, frame, protocol_version) do
+    Logging.server_event("session_auto_initialized", %{
+      session_id: auto_state.session_id,
+      protocol_version: protocol_version
+    })
+
+    maybe_persist_session(%{auto_state | frame: frame})
+    {:reply, :ok, %{auto_state | frame: frame}}
   end
 
   defp maybe_persist_session(%{session_id: session_id} = state) do

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -214,10 +214,7 @@ defmodule Anubis.Server.Session do
           {:reply, {:error, {:recovery_rejected, reason}}, state}
 
         :default ->
-          case maybe_call_init(module, auto_state.client_info, frame) do
-            {:ok, frame} -> do_complete_auto_init(auto_state, frame, protocol_version)
-            {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
-          end
+          fallback_to_init(module, auto_state, frame, protocol_version, state)
       end
     else
       [] -> {:reply, {:error, :no_supported_versions}, state}
@@ -1061,6 +1058,13 @@ defmodule Anubis.Server.Session do
           _ ->
             {nil, nil}
         end
+    end
+  end
+
+  defp fallback_to_init(module, auto_state, frame, protocol_version, state) do
+    case maybe_call_init(module, auto_state.client_info, frame) do
+      {:ok, frame} -> do_complete_auto_init(auto_state, frame, protocol_version)
+      {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
     end
   end
 

--- a/test/anubis/server/session_expiry_test.exs
+++ b/test/anubis/server/session_expiry_test.exs
@@ -1,0 +1,129 @@
+defmodule Anubis.Server.SessionExpiryTest do
+  use Anubis.MCP.Case, async: false
+
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Session
+  alias Anubis.Test.MockSessionStore
+
+  @moduletag capture_log: true
+
+  defp start_session(server_module, session_id, extra_opts \\ []) do
+    transport_name = Registry.transport_name(server_module, StubTransport)
+    task_sup = Registry.task_supervisor_name(server_module)
+    session_name = Registry.session_name(server_module, session_id)
+
+    start_supervised!({StubTransport, name: transport_name}, id: :"transport_#{session_id}")
+    start_supervised!({Task.Supervisor, name: task_sup}, id: :"task_sup_#{session_id}")
+
+    opts =
+      [
+        session_id: session_id,
+        server_module: server_module,
+        name: session_name,
+        transport: [layer: StubTransport, name: transport_name],
+        task_supervisor: task_sup
+      ] ++ extra_opts
+
+    start_supervised!({Session, opts}, id: :"session_#{session_id}")
+  end
+
+  describe "auto_initialize/1 default behavior" do
+    test "marks session as initialized with synthetic client info" do
+      session_id = "auto-init-default-#{System.unique_integer([:positive])}"
+      session = start_session(StubServer, session_id)
+
+      assert :ok = Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      assert state.initialized
+      assert state.client_info == %{"name" => "auto-recovered", "version" => "unknown"}
+    end
+
+    test "is idempotent when already initialized" do
+      session_id = "auto-init-idempotent-#{System.unique_integer([:positive])}"
+      session = start_session(StubServer, session_id)
+
+      assert :ok = Session.auto_initialize(session)
+      assert :ok = Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      assert state.initialized
+    end
+  end
+
+  describe "auto_initialize/1 with session store" do
+    setup do
+      {:ok, _} = MockSessionStore.start_link([])
+      MockSessionStore.reset!()
+
+      Application.put_env(:anubis_mcp, :session_store,
+        enabled: true,
+        adapter: MockSessionStore
+      )
+
+      on_exit(fn -> Application.delete_env(:anubis_mcp, :session_store) end)
+
+      :ok
+    end
+
+    test "restores client_info and frame assigns from store" do
+      session_id = "store-restore-#{System.unique_integer([:positive])}"
+
+      saved_client_info = %{"name" => "real-client", "version" => "2.0"}
+
+      MockSessionStore.save(
+        session_id,
+        %{
+          "id" => session_id,
+          "client_info" => saved_client_info,
+          "frame" => %{"assigns" => %{"key" => "value"}, "pagination_limit" => nil}
+        },
+        []
+      )
+
+      session = start_session(StubServer, session_id)
+
+      assert :ok = Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      assert state.client_info == saved_client_info
+      # assigns come back from store with string keys (JSON serialization round-trip)
+      assert state.frame.assigns["key"] == "value"
+    end
+
+    test "falls back to synthetic client_info when store has no entry" do
+      session_id = "store-miss-#{System.unique_integer([:positive])}"
+      session = start_session(StubServer, session_id)
+
+      assert :ok = Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      assert state.client_info == %{"name" => "auto-recovered", "version" => "unknown"}
+    end
+  end
+
+  describe "handle_session_expired/2 callback" do
+    test "callback receives session_id and frame, can return custom client_info" do
+      session_id = "expiry-cb-#{System.unique_integer([:positive])}"
+      session = start_session(StubSessionRecoveryServer, session_id)
+
+      assert :ok = Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      assert state.initialized
+      assert state.client_info == %{"name" => "recovered-client", "version" => "1.0"}
+      assert state.frame.assigns[:recovery_ran] == true
+    end
+
+    test "callback returning {:error, reason} causes auto_initialize to fail" do
+      session_id = "expiry-reject-#{System.unique_integer([:positive])}"
+      session = start_session(StubSessionRecoveryRejectServer, session_id)
+
+      assert {:error, {:recovery_rejected, :no_recovery_allowed}} =
+               Session.auto_initialize(session)
+
+      state = :sys.get_state(session)
+      refute state.initialized
+    end
+  end
+end

--- a/test/support/stub_session_recovery_server.ex
+++ b/test/support/stub_session_recovery_server.ex
@@ -1,0 +1,49 @@
+defmodule StubSessionRecoveryServer do
+  @moduledoc """
+  Test server that implements handle_session_expired/2, supplying custom
+  client info and marking the frame with a recovery flag.
+  """
+
+  use Anubis.Server,
+    name: "Recovery Test Server",
+    version: "1.0.0",
+    capabilities: []
+
+  import Anubis.Server.Frame, only: [assign: 3]
+
+  alias Anubis.MCP.Error
+
+  @impl true
+  def handle_request(%{"method" => _}, frame) do
+    {:error, Error.protocol(:method_not_found), frame}
+  end
+
+  @impl true
+  def handle_session_expired(_session_id, frame) do
+    frame = assign(frame, :recovery_ran, true)
+    {:ok, %{"name" => "recovered-client", "version" => "1.0"}, frame}
+  end
+end
+
+defmodule StubSessionRecoveryRejectServer do
+  @moduledoc """
+  Test server that rejects session recovery via handle_session_expired/2.
+  """
+
+  use Anubis.Server,
+    name: "Reject Recovery Test Server",
+    version: "1.0.0",
+    capabilities: []
+
+  alias Anubis.MCP.Error
+
+  @impl true
+  def handle_request(%{"method" => _}, frame) do
+    {:error, Error.protocol(:method_not_found), frame}
+  end
+
+  @impl true
+  def handle_session_expired(_session_id, _frame) do
+    {:error, :no_recovery_allowed}
+  end
+end


### PR DESCRIPTION
## Problem

When a session expires due to inactivity (`session_idle_timeout`), the next request from the client fails with \"Server not initialized\". The library auto-creates a new session but it defaults to `initialized: false`, blocking non-initialize requests. There was also no way for server implementations to customize recovery behavior or distinguish auto-recovery from a fresh handshake.

Closes #53.

## Solution

- Adds an optional `handle_session_expired/2` callback to `Anubis.Server` behaviour. Servers can return `{:ok, frame}`, `{:ok, client_info, frame}`, or `{:error, reason}` to accept (with optional custom client info) or reject recovery.
- When a session store is configured, `auto_initialize/1` now attempts to restore `client_info` and frame assigns from the store before invoking the callback, so implementations don't need to duplicate store-load logic.
- If the callback is not implemented, behavior is unchanged (backward compatible): synthetic client info is used and `init/2` is called normally.
- Adds test support servers and a dedicated test file covering all recovery paths.

## Rationale

Auto-recovery for requests is a pragmatic extension of the existing behavior — the client is blocked waiting and has no way to self-recover. Notifications and responses intentionally keep returning 404 per the MCP spec ("server SHOULD respond with HTTP 404 Not Found" for unknown session IDs), which is the correct signal for a client to re-initialize.

The `:default` sentinel from `maybe_call_session_expired/3` cleanly separates "callback not defined" from `{:ok, frame}`, preserving the exact original `init/2` fallback path without ambiguity.