### PR TITLE
fix: replace opaque KeyError with ArgumentError for missing :client_info

### DIFF
--- a/lib/anubis/client/supervisor.ex
+++ b/lib/anubis/client/supervisor.ex
@@ -65,7 +65,18 @@ defmodule Anubis.Client.Supervisor do
   def init(opts) do
     transport = Keyword.fetch!(opts, :transport)
 
-    client_info = Keyword.fetch!(opts, :client_info)
+    client_info =
+      Keyword.get(opts, :client_info) ||
+        raise ArgumentError, """
+        :client_info is required when starting Anubis.Client.
+
+        Example:
+          {Anubis.Client,
+           name: MyApp.MCPClient,
+           client_info: %{"name" => "MyApp", "version" => "1.0.0"},
+           transport: {:streamable_http, base_url: "http://localhost:9999"}}
+        """
+
     capabilities = Keyword.get(opts, :capabilities, %{})
     protocol_version = Keyword.get(opts, :protocol_version, Anubis.Protocol.latest_version())
 


### PR DESCRIPTION
## Problem

When starting `Anubis.Client` without the `:client_info` option, the supervisor crashes with an opaque `KeyError: key :client_info not found` that gives no hint on how to fix it.

## Solution

Replace `Keyword.fetch!(opts, :client_info)` in `Anubis.Client.Supervisor.init/1` with an explicit `ArgumentError` that includes a usage example, consistent with the existing error for missing `:transport_name`.

Closes #79.

## Rationale

The `use Anubis.Client` macro pattern reported in the issue no longer exists, but the bad error message was still a real DX issue. The minimal fix is aligning this error with the already-good pattern used for the `:transport_name` case.