### PR TITLE
fix: server stdio test againts custom io device

### DIFF
--- a/lib/anubis/server/transport/stdio.ex
+++ b/lib/anubis/server/transport/stdio.ex
@@ -37,7 +37,8 @@ defmodule Anubis.Server.Transport.STDIO do
   defschema(:parse_options, [
     {:server, {:required, {:oneof, [{:custom, &Anubis.genserver_name/1}, :pid, {:tuple, [:atom, :any]}]}}},
     {:name, {:custom, &Anubis.genserver_name/1}},
-    {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}}
+    {:request_timeout, {:integer, {:default, to_timeout(second: 30)}}},
+    {:io_device, {:any, {:default, :stdio}}}
   ])
 
   @impl Transport
@@ -84,7 +85,8 @@ defmodule Anubis.Server.Transport.STDIO do
     state = %{
       server: opts.server,
       reading_task: nil,
-      request_timeout: opts.request_timeout
+      request_timeout: opts.request_timeout,
+      io_device: opts.io_device
     }
 
     Logger.metadata(mcp_transport: :stdio, mcp_server: state.server)
@@ -100,20 +102,20 @@ defmodule Anubis.Server.Transport.STDIO do
   end
 
   @impl GenServer
-  def handle_continue(:start_reading, state) do
-    task = Task.async(fn -> read_from_stdin() end)
+  def handle_continue(:start_reading, %{io_device: device} = state) do
+    task = Task.async(fn -> read_from_stdin(device) end)
     {:noreply, %{state | reading_task: task}}
   end
 
   @impl GenServer
-  def handle_info({ref, result}, %{reading_task: %Task{ref: ref}} = state) when is_reference(ref) do
+  def handle_info({ref, result}, %{reading_task: %Task{ref: ref}, io_device: device} = state) when is_reference(ref) do
     Process.demonitor(ref, [:flush])
 
     case result do
       {:ok, data} ->
         handle_incoming_data(data, state)
 
-        task = Task.async(fn -> read_from_stdin() end)
+        task = Task.async(fn -> read_from_stdin(device) end)
         {:noreply, %{state | reading_task: task}}
 
       {:error, :eof} ->
@@ -144,7 +146,7 @@ defmodule Anubis.Server.Transport.STDIO do
       %{transport: :stdio, message_size: byte_size(message)}
     )
 
-    IO.write(message)
+    IO.write(state.io_device, message)
     {:reply, :ok, state}
   end
 
@@ -165,7 +167,8 @@ defmodule Anubis.Server.Transport.STDIO do
 
   @impl GenServer
   def terminate(reason, _state) do
-    Logging.transport_event("terminating", %{reason: reason}, level: :info)
+    level = if reason in [:normal, :shutdown] or match?({:shutdown, _}, reason), do: :debug, else: :info
+    Logging.transport_event("terminating", %{reason: reason}, level: level)
 
     Telemetry.execute(
       Telemetry.event_transport_terminate(),
@@ -178,8 +181,8 @@ defmodule Anubis.Server.Transport.STDIO do
 
   # Private helper functions
 
-  defp read_from_stdin do
-    case IO.read(:stdio, :line) do
+  defp read_from_stdin(device) do
+    case IO.read(device, :line) do
       :eof ->
         Logging.transport_event("eof", "End of input stream", level: :info)
 
@@ -257,14 +260,14 @@ defmodule Anubis.Server.Transport.STDIO do
     if Message.is_notification(message) do
       GenServer.cast(session_pid, {:mcp_notification, message, context})
     else
-      forward_request_to_session(session_pid, message, context, state.request_timeout)
+      forward_request_to_session(session_pid, message, context, state)
     end
   end
 
-  defp forward_request_to_session(session_pid, message, context, timeout) do
-    case GenServer.call(session_pid, {:mcp_request, message, context}, timeout) do
+  defp forward_request_to_session(session_pid, message, context, state) do
+    case GenServer.call(session_pid, {:mcp_request, message, context}, state.request_timeout) do
       {:ok, response} when is_binary(response) ->
-        IO.write(response <> "\n")
+        IO.write(state.io_device, response <> "\n")
 
       {:ok, nil} ->
         :ok

--- a/test/anubis/server/transport/stdio_test.exs
+++ b/test/anubis/server/transport/stdio_test.exs
@@ -1,91 +1,72 @@
 defmodule Anubis.Server.Transport.STDIOTest do
   use Anubis.MCP.Case, async: false
 
-  import ExUnit.CaptureLog
-
   alias Anubis.Server.Transport.STDIO
 
-  @moduletag capture_log: true, capture_io: true
+  @moduletag capture_log: true
 
   setup :server_with_stdio_transport
 
   describe "start_link/1" do
-    test "starts successfully with valid options", %{server: server} do
+    test "starts successfully with valid options", %{server: server, io_device: io_device} do
       name = :"test_stdio_transport_#{:rand.uniform(1_000_000)}"
-      opts = [server: server, name: name]
 
-      capture_log(fn ->
-        assert {:ok, pid} = STDIO.start_link(opts)
-        assert Process.alive?(pid)
-        assert Process.whereis(name) == pid
-        shutdown(pid)
-      end)
+      assert {:ok, pid} = STDIO.start_link(server: server, name: name, io_device: io_device)
+      assert Process.alive?(pid)
+      assert Process.whereis(name) == pid
+      shutdown(pid)
     end
   end
 
   describe "send_message/2" do
-    test "sends message via cast", %{server: server} do
+    test "sends message via cast", %{server: server, io_device: io_device} do
       name = :"test_send_message_#{:rand.uniform(1_000_000)}"
-      {:ok, string_io} = StringIO.open("")
 
-      capture_log(fn ->
-        {:ok, pid} = STDIO.start_link(server: server, name: name)
-        Process.group_leader(pid, string_io)
+      {:ok, pid} = STDIO.start_link(server: server, name: name, io_device: io_device)
 
-        assert :ok = STDIO.send_message(pid, "test message", timeout: 5000)
+      assert :ok = STDIO.send_message(pid, "test message", timeout: 5000)
 
-        {_input, output} = StringIO.contents(string_io)
-        assert output =~ "test message"
+      assert TestIODevice.contents(io_device) =~ "test message"
 
-        shutdown(pid)
-      end)
-
-      StringIO.close(string_io)
+      shutdown(pid)
     end
   end
 
   describe "shutdown/1" do
-    test "shuts down the transport gracefully", %{server: server} do
+    test "shuts down the transport gracefully", %{server: server, io_device: io_device} do
       name = :"shutdown_test_#{:rand.uniform(1_000_000)}"
 
-      capture_log(fn ->
-        {:ok, pid} = STDIO.start_link(server: server, name: name)
-        ref = Process.monitor(pid)
+      {:ok, pid} = STDIO.start_link(server: server, name: name, io_device: io_device)
+      ref = Process.monitor(pid)
 
-        assert :ok = STDIO.shutdown(pid)
-        assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
+      assert :ok = STDIO.shutdown(pid)
+      assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1000
 
-        refute Process.whereis(name)
-      end)
+      refute Process.whereis(name)
     end
   end
 
   describe "basic functionality" do
-    test "starts and stops cleanly", %{server: server} do
+    test "starts and stops cleanly", %{server: server, io_device: io_device} do
       name = :"basic_test_#{:rand.uniform(1_000_000)}"
 
-      capture_log(fn ->
-        assert {:ok, pid} = STDIO.start_link(server: server, name: name)
-        assert Process.alive?(pid)
-        shutdown(pid)
-      end)
+      assert {:ok, pid} = STDIO.start_link(server: server, name: name, io_device: io_device)
+      assert Process.alive?(pid)
+      shutdown(pid)
     end
 
-    test "manages reading tasks correctly", %{server: server} do
+    test "manages reading tasks correctly", %{server: server, io_device: io_device} do
       name = :"async_test_#{:rand.uniform(1_000_000)}"
 
-      capture_log(fn ->
-        {:ok, pid} = STDIO.start_link(server: server, name: name)
-        assert Process.alive?(pid)
-        shutdown(pid)
-      end)
+      {:ok, pid} = STDIO.start_link(server: server, name: name, io_device: io_device)
+      assert Process.alive?(pid)
+      shutdown(pid)
     end
   end
 
   defp shutdown(pid) do
     ref = Process.monitor(pid)
     :ok = STDIO.shutdown(pid)
-    :ok = Logger.flush()
     assert_receive {:DOWN, ^ref, _, ^pid, :normal}
   end
 end

--- a/test/support/mcp/setup.ex
+++ b/test/support/mcp/setup.ex
@@ -136,10 +136,12 @@ defmodule Anubis.MCP.Setup do
          task_supervisor: task_sup}
       )
 
-    transport =
-      start_supervised!({STDIO, name: transport_name, server: server_module})
+    io_device = start_supervised!({TestIODevice, []})
 
-    Map.merge(ctx, %{server: session, transport: transport})
+    transport =
+      start_supervised!({STDIO, name: transport_name, server: server_module, io_device: io_device})
+
+    Map.merge(ctx, %{server: session, transport: transport, io_device: io_device})
   end
 
   def initialized_client(context) do

--- a/test/support/test_io_device.ex
+++ b/test/support/test_io_device.ex
@@ -1,0 +1,77 @@
+defmodule TestIODevice do
+  @moduledoc """
+  Minimal Erlang IO-protocol server for exercising `Anubis.Server.Transport.STDIO` in tests.
+
+  Read requests are intentionally never replied to, so a reader task blocks forever
+  instead of seeing `:eof` — this mirrors a live stdin while keeping tests deterministic.
+  Write requests are buffered and can be retrieved via `contents/1`.
+  """
+
+  use GenServer
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, :ok, opts)
+  end
+
+  @spec contents(GenServer.server()) :: binary()
+  def contents(device) do
+    GenServer.call(device, :contents)
+  end
+
+  @impl GenServer
+  def init(:ok) do
+    {:ok, %{output: []}}
+  end
+
+  @impl GenServer
+  def handle_info({:io_request, from, reply_as, request}, state) do
+    handle_io_request(request, from, reply_as, state)
+  end
+
+  @impl GenServer
+  def handle_call(:contents, _from, state) do
+    {:reply, state.output |> Enum.reverse() |> IO.iodata_to_binary(), state}
+  end
+
+  defp handle_io_request({:put_chars, _encoding, chars}, from, reply_as, state) do
+    send(from, {:io_reply, reply_as, :ok})
+    {:noreply, %{state | output: [chars | state.output]}}
+  end
+
+  defp handle_io_request({:put_chars, chars}, from, reply_as, state) do
+    send(from, {:io_reply, reply_as, :ok})
+    {:noreply, %{state | output: [chars | state.output]}}
+  end
+
+  defp handle_io_request({:put_chars, _encoding, mod, fun, args}, from, reply_as, state) do
+    chars = apply(mod, fun, args)
+    send(from, {:io_reply, reply_as, :ok})
+    {:noreply, %{state | output: [chars | state.output]}}
+  end
+
+  defp handle_io_request({:get_line, _encoding, _prompt}, _from, _reply_as, state), do: {:noreply, state}
+  defp handle_io_request({:get_line, _prompt}, _from, _reply_as, state), do: {:noreply, state}
+  defp handle_io_request({:get_chars, _encoding, _prompt, _n}, _from, _reply_as, state), do: {:noreply, state}
+  defp handle_io_request({:get_chars, _prompt, _n}, _from, _reply_as, state), do: {:noreply, state}
+
+  defp handle_io_request({:get_until, _encoding, _prompt, _mod, _fun, _args}, _from, _reply_as, state),
+    do: {:noreply, state}
+
+  defp handle_io_request({:get_until, _prompt, _mod, _fun, _args}, _from, _reply_as, state), do: {:noreply, state}
+
+  defp handle_io_request({:setopts, _opts}, from, reply_as, state) do
+    send(from, {:io_reply, reply_as, :ok})
+    {:noreply, state}
+  end
+
+  defp handle_io_request(:getopts, from, reply_as, state) do
+    send(from, {:io_reply, reply_as, [binary: true, encoding: :utf8]})
+    {:noreply, state}
+  end
+
+  defp handle_io_request(_other, from, reply_as, state) do
+    send(from, {:io_reply, reply_as, {:error, :request}})
+    {:noreply, state}
+  end
+end


### PR DESCRIPTION
## Problem

`Anubis.Server.Transport.STDIO` reads from a hardcoded `:stdio` device. In CI (non-TTY stdin), `IO.read(:stdio, :line)` returns `:eof` immediately after `start_link`, triggering an eof/terminate log cascade that leaks into test output because Logger is async and fires after `capture_log` scope ends. The existing `Process.group_leader(pid, string_io)` workaround in `stdio_test.exs` runs *after* `start_link`, so the already-spawned reader task misses it.

## Solution

- Add an `:io_device` option to `Anubis.Server.Transport.STDIO` (default `:stdio`). Thread it through every `IO.read`/`IO.write` site — the reader task, `send_message`, and the session response write.
- Add `TestIODevice` — a minimal IO-protocol GenServer for tests that never replies to read requests (so the reader blocks cleanly) and buffers writes for assertion.
- Update `server_with_stdio_transport` helper to spawn a `TestIODevice` and inject it into the supervised transport; expose it via context.
- Rewrite `stdio_test.exs` to use the injected device instead of the `group_leader` hack.
- Demote `terminate/2` log to `:debug` for `:normal` / `:shutdown` reasons so expected teardown doesn't emit INFO noise past the test's capture scope.

## Rationale

Making the IO device injectable is a principled test seam — it matches how other transports separate IO from logic, keeps production behavior identical (default `:stdio`), and removes reliance on group-leader rebinding (which races with the reader task). Blocking on reads rather than EOFing eliminates the cascade at the source. The log-level tweak avoids INFO emissions for expected lifecycle transitions that are already observable via telemetry.
