### PR TITLE
fix: defer streamable_http plug opts fetching to runtime

### DIFF
--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -54,16 +54,11 @@ if Code.ensure_loaded?(Plug) do
     @impl Plug
     def init(opts) do
       server = Keyword.fetch!(opts, :server)
-      session_config = ServerSupervisor.get_session_config(server)
-      transport_name = Registry.transport_name(server, :streamable_http)
       session_header = Keyword.get(opts, :session_header, @default_session_header)
       request_timeout = Keyword.get(opts, :request_timeout, @default_timeout)
 
       %{
         server: server,
-        registry_mod: session_config.registry_mod,
-        registry_name: Registry.registry_name(server),
-        transport: transport_name,
         session_header: session_header,
         timeout: request_timeout
       }
@@ -71,12 +66,24 @@ if Code.ensure_loaded?(Plug) do
 
     @impl Plug
     def call(conn, opts) do
+      opts = resolve_runtime_config(opts)
+
       case conn.method do
         "GET" -> handle_get(conn, opts)
         "POST" -> handle_post(conn, opts)
         "DELETE" -> handle_delete(conn, opts)
         _ -> send_error(conn, 405, "Method not allowed")
       end
+    end
+
+    defp resolve_runtime_config(%{server: server} = opts) do
+      session_config = ServerSupervisor.get_session_config(server)
+
+      Map.merge(opts, %{
+        registry_mod: session_config.registry_mod,
+        registry_name: Registry.registry_name(server),
+        transport: Registry.transport_name(server, :streamable_http)
+      })
     end
 
     # GET request handler - establishes SSE connection

--- a/test/anubis/server/transport/streamable_http/plug_test.exs
+++ b/test/anubis/server/transport/streamable_http/plug_test.exs
@@ -51,12 +51,9 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
       opts = StreamableHTTPPlug.init(server: StubServer)
 
       assert %{
-               transport: transport,
                session_header: "mcp-session-id",
                timeout: 30_000
              } = opts
-
-      assert transport == Registry.transport_name(StubServer, :streamable_http)
     end
 
     test "accepts custom session header" do
@@ -67,12 +64,9 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
         )
 
       assert %{
-               transport: transport,
                session_header: "x-custom-session",
                timeout: 30_000
              } = opts
-
-      assert transport == Registry.transport_name(StubServer, :streamable_http)
     end
   end
 


### PR DESCRIPTION
## Problem

`StreamableHTTP.Plug.init/1` reads a persistent term (`session_config`) that only exists at runtime, causing a compilation
error when used with `Plug.Router` (which evaluates `init/1` at compile time). Phoenix routers defer `init/1` to runtime,
masking the issue.

## Solution

Move the `ServerSupervisor.get_session_config/1` and registry lookups from `init/1` to `call/2` via a
`resolve_runtime_config/1` helper. `init/1` now only captures static options (`:server`, `:session_header`,
`:request_timeout`).

## Rationale

`Plug.init/1` must be safe to call at compile time per the Plug contract. Runtime state belongs in `call/2`. This matches how
`SSE.Plug` already works.
