### PR TITLE
feat: resource templates with RFC 6570 URI matching

### DIFF
--- a/lib/anubis/server/component.ex
+++ b/lib/anubis/server/component.ex
@@ -4,6 +4,7 @@ defmodule Anubis.Server.Component do
   alias Anubis.Server.Component.Prompt
   alias Anubis.Server.Component.Resource
   alias Anubis.Server.Component.Tool
+  alias Anubis.Server.Component.URITemplate
 
   @doc false
   # credo:disable-for-next-line Credo.Check.Refactor.CyclomaticComplexity
@@ -21,6 +22,22 @@ defmodule Anubis.Server.Component do
 
     uri = Keyword.get(opts, :uri)
     uri_template = Keyword.get(opts, :uri_template)
+
+    if (type == :resource and uri) && uri_template do
+      raise ArgumentError,
+            "Resource component cannot define both :uri and :uri_template (mutually exclusive)"
+    end
+
+    if type == :resource and uri_template do
+      case URITemplate.parse(uri_template) do
+        {:ok, _} ->
+          :ok
+
+        {:error, reason} ->
+          raise ArgumentError, "Invalid :uri_template — #{reason}"
+      end
+    end
+
     basename = if uri && type == :resource, do: Path.basename(uri)
     name = Keyword.get(opts, :name, basename)
     mime_type = Keyword.get(opts, :mime_type, "text/plain")

--- a/lib/anubis/server/component/resource.ex
+++ b/lib/anubis/server/component/resource.ex
@@ -40,6 +40,32 @@ defmodule Anubis.Server.Component.Resource do
         end
       end
 
+  ## Example with URI template (parameterized resource)
+
+      defmodule MyServer.Resources.UserDoc do
+        use Anubis.Server.Component,
+          type: :resource,
+          uri_template: "file:///docs/{user}/{filename}"
+
+        alias Anubis.Server.Response
+
+        @impl true
+        def read(%{"params" => %{"user" => user, "filename" => name}}, frame) do
+          path = Path.join(["docs", user, name])
+
+          case File.read(path) do
+            {:ok, content} ->
+              {:reply, Response.text(Response.resource(), content), frame}
+
+            {:error, _} ->
+              {:error, Anubis.MCP.Error.resource(:not_found, %{message: "no such file"}), frame}
+          end
+        end
+      end
+
+  Variables in `uri_template` follow RFC 6570 (Level 1 — simple `{var}` expansion).
+  Extracted variables are delivered to `read/2` as the `"params"` key of the first argument.
+
   ## Example with dynamic content
 
       defmodule MyServer.Resources.SystemStatus do

--- a/lib/anubis/server/component/uri_template.ex
+++ b/lib/anubis/server/component/uri_template.ex
@@ -1,0 +1,150 @@
+defmodule Anubis.Server.Component.URITemplate do
+  @moduledoc """
+  RFC 6570 URI Template parser and matcher (Levels 1 and 2).
+
+  Supported expressions:
+
+  | Form        | Level | Description                          |
+  |-------------|-------|--------------------------------------|
+  | `{var}`     | 1     | Simple expansion (excludes `/?#`)    |
+  | `{+var}`    | 2     | Reserved expansion (allows reserved) |
+  | `{#var}`    | 2     | Fragment expansion (literal `#`)     |
+
+  Level 3 (multi-var, label, path-segment, query) and Level 4 (prefix, explode)
+  are not supported.
+
+  ## Examples
+
+      iex> {:ok, t} = URITemplate.parse("file:///{path}")
+      iex> URITemplate.match(t, "file:///docs/readme.md")
+      {:ok, %{"path" => "docs/readme.md"}}
+
+      iex> {:ok, t} = URITemplate.parse("db:///{table}/{id}")
+      iex> URITemplate.match(t, "db:///users/42")
+      {:ok, %{"table" => "users", "id" => "42"}}
+
+      iex> {:ok, t} = URITemplate.parse("file:///{+path}")
+      iex> URITemplate.match(t, "file:///deep/nested/file.md")
+      {:ok, %{"path" => "deep/nested/file.md"}}
+
+      iex> {:ok, t} = URITemplate.parse("/page{#section}")
+      iex> URITemplate.match(t, "/page#intro")
+      {:ok, %{"section" => "intro"}}
+  """
+
+  @type t :: %__MODULE__{
+          raw: String.t(),
+          vars: [String.t()],
+          regex: Regex.t()
+        }
+
+  defstruct [:raw, :vars, :regex]
+
+  @expr_pattern ~r/\{([+#]?)([a-zA-Z_][a-zA-Z0-9_]*)\}/
+
+  @doc """
+  Parses an RFC 6570 (Level 1 + Level 2) URI template string.
+
+  Returns `{:ok, %URITemplate{}}` on success, `{:error, reason}` otherwise.
+  """
+  @spec parse(String.t()) :: {:ok, t} | {:error, String.t()}
+  def parse(template) when is_binary(template) do
+    if (String.contains?(template, "{") or String.contains?(template, "}")) and
+         not valid_braces?(template) do
+      {:error, "unbalanced or invalid braces in template: #{inspect(template)}"}
+    else
+      vars = extract_vars(template)
+
+      case vars -- Enum.uniq(vars) do
+        [] ->
+          {:ok, %__MODULE__{raw: template, vars: vars, regex: build_regex(template)}}
+
+        dups ->
+          {:error, "duplicate variables #{inspect(Enum.uniq(dups))} in template"}
+      end
+    end
+  end
+
+  def parse(_), do: {:error, "template must be a string"}
+
+  @doc """
+  Same as `parse/1` but raises `ArgumentError` on failure.
+  """
+  @spec parse!(String.t()) :: t
+  def parse!(template) do
+    case parse(template) do
+      {:ok, t} -> t
+      {:error, reason} -> raise ArgumentError, reason
+    end
+  end
+
+  @doc """
+  Matches a URI against a parsed template (or template string).
+
+  Returns `{:ok, vars_map}` on a match where keys are variable names and
+  values are the percent-decoded substrings, or `:error` if the URI does not
+  match the template.
+  """
+  @spec match(t | String.t(), String.t()) :: {:ok, map} | :error
+  def match(%__MODULE__{} = t, uri) when is_binary(uri) do
+    case Regex.run(t.regex, uri, capture: :all_but_first) do
+      nil ->
+        :error
+
+      captures ->
+        pairs =
+          t.vars
+          |> Enum.zip(captures)
+          |> Map.new(fn {k, v} -> {k, URI.decode(v)} end)
+
+        {:ok, pairs}
+    end
+  end
+
+  def match(template, uri) when is_binary(template) and is_binary(uri) do
+    case parse(template) do
+      {:ok, t} -> match(t, uri)
+      _ -> :error
+    end
+  end
+
+  defp extract_vars(template) do
+    @expr_pattern
+    |> Regex.scan(template, capture: :all_but_first)
+    |> Enum.map(fn [_op, name] -> name end)
+  end
+
+  defp valid_braces?(template) do
+    opens = template |> String.graphemes() |> Enum.count(&(&1 == "{"))
+    closes = template |> String.graphemes() |> Enum.count(&(&1 == "}"))
+
+    opens == closes and
+      Regex.match?(~r/^([^{}]|\{[+#]?[a-zA-Z_][a-zA-Z0-9_]*\})*$/, template)
+  end
+
+  defp build_regex(template) do
+    pattern =
+      template
+      |> split_template()
+      |> Enum.map_join(fn
+        {:literal, lit} -> Regex.escape(lit)
+        {:var, "", _name} -> "([^/?#]+)"
+        {:var, "+", _name} -> "([^#]+)"
+        {:var, "#", _name} -> "#(.+)"
+      end)
+
+    Regex.compile!("^" <> pattern <> "$")
+  end
+
+  defp split_template(template) do
+    template
+    |> then(&Regex.split(@expr_pattern, &1, include_captures: true))
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.map(fn part ->
+      case Regex.run(@expr_pattern, part) do
+        [_full, op, name] -> {:var, op, name}
+        _ -> {:literal, part}
+      end
+    end)
+  end
+end

--- a/lib/anubis/server/handlers/resources.ex
+++ b/lib/anubis/server/handlers/resources.ex
@@ -3,6 +3,7 @@ defmodule Anubis.Server.Handlers.Resources do
 
   alias Anubis.MCP.Error
   alias Anubis.Server.Component.Resource
+  alias Anubis.Server.Component.URITemplate
   alias Anubis.Server.Frame
   alias Anubis.Server.Handlers
   alias Anubis.Server.Response
@@ -61,19 +62,24 @@ defmodule Anubis.Server.Handlers.Resources do
   end
 
   defp try_resource_templates([template | rest], server, uri, frame) do
-    case read_single_resource(server, template, uri, frame) do
-      {:error, %Error{code: -32_002}, _frame} ->
-        # Try templates sequentially until one matches or all fail
-        try_resource_templates(rest, server, uri, frame)
+    case URITemplate.match(template.uri_template, uri) do
+      {:ok, vars} ->
+        case read_single_resource(server, template, uri, frame, vars) do
+          {:error, %Error{code: -32_002}, _frame} ->
+            try_resource_templates(rest, server, uri, frame)
 
-      result ->
-        # Either success or a different error (e.g., permission denied)
-        # Return immediately - don't try other templates
-        result
+          result ->
+            result
+        end
+
+      :error ->
+        try_resource_templates(rest, server, uri, frame)
     end
   end
 
-  defp read_single_resource(server, %Resource{handler: nil, mime_type: mime_type}, uri, frame) do
+  defp read_single_resource(server, resource, uri, frame, vars \\ %{})
+
+  defp read_single_resource(server, %Resource{handler: nil, mime_type: mime_type}, uri, frame, _vars) do
     case server.handle_resource_read(uri, frame) do
       {:reply, %Response{} = response, frame} ->
         content = Response.to_protocol(response, uri, mime_type)
@@ -88,8 +94,8 @@ defmodule Anubis.Server.Handlers.Resources do
     end
   end
 
-  defp read_single_resource(_server, %Resource{handler: handler, mime_type: mime_type}, uri, frame) do
-    case handler.read(%{"uri" => uri}, frame) do
+  defp read_single_resource(_server, %Resource{handler: handler, mime_type: mime_type}, uri, frame, vars) do
+    case handler.read(%{"uri" => uri, "params" => vars}, frame) do
       {:reply, %Response{} = response, frame} ->
         content = Response.to_protocol(response, uri, mime_type)
         {:reply, %{"contents" => [content]}, frame}

--- a/test/anubis/server/component/uri_template_test.exs
+++ b/test/anubis/server/component/uri_template_test.exs
@@ -1,0 +1,98 @@
+defmodule Anubis.Server.Component.URITemplateTest do
+  use ExUnit.Case, async: true
+
+  alias Anubis.Server.Component.URITemplate
+
+  describe "parse/1" do
+    test "parses template with single variable" do
+      assert {:ok, %URITemplate{vars: ["path"], raw: "file:///{path}"}} =
+               URITemplate.parse("file:///{path}")
+    end
+
+    test "parses template with multiple variables" do
+      assert {:ok, %URITemplate{vars: ["table", "id"]}} =
+               URITemplate.parse("db:///{table}/{id}")
+    end
+
+    test "parses template with no variables" do
+      assert {:ok, %URITemplate{vars: []}} = URITemplate.parse("file:///static")
+    end
+
+    test "rejects unbalanced braces" do
+      assert {:error, _} = URITemplate.parse("file:///{path")
+      assert {:error, _} = URITemplate.parse("file:///path}")
+    end
+
+    test "rejects duplicate variables" do
+      assert {:error, reason} = URITemplate.parse("/{x}/{x}")
+      assert reason =~ "duplicate"
+    end
+
+    test "rejects non-string input" do
+      assert {:error, _} = URITemplate.parse(:atom)
+    end
+  end
+
+  describe "parse!/1" do
+    test "raises on invalid template" do
+      assert_raise ArgumentError, fn -> URITemplate.parse!("file:///{bad") end
+    end
+  end
+
+  describe "match/2" do
+    test "matches single variable" do
+      {:ok, t} = URITemplate.parse("file:///{path}")
+      assert {:ok, %{"path" => "readme.md"}} = URITemplate.match(t, "file:///readme.md")
+    end
+
+    test "matches multiple variables" do
+      {:ok, t} = URITemplate.parse("db:///{table}/{id}")
+      assert {:ok, %{"table" => "users", "id" => "42"}} = URITemplate.match(t, "db:///users/42")
+    end
+
+    test "returns :error on non-match" do
+      {:ok, t} = URITemplate.parse("file:///{path}")
+      assert :error = URITemplate.match(t, "http://example.com")
+    end
+
+    test "does not greedily span path separators" do
+      {:ok, t} = URITemplate.parse("db:///{table}/{id}")
+      assert :error = URITemplate.match(t, "db:///users")
+    end
+
+    test "percent-decodes captured values" do
+      {:ok, t} = URITemplate.parse("file:///{path}")
+      assert {:ok, %{"path" => "hello world"}} = URITemplate.match(t, "file:///hello%20world")
+    end
+
+    test "accepts a raw template string" do
+      assert {:ok, %{"path" => "x"}} = URITemplate.match("file:///{path}", "file:///x")
+    end
+  end
+
+  describe "Level 2 — reserved expansion {+var}" do
+    test "matches path with slashes" do
+      {:ok, t} = URITemplate.parse("file:///{+path}")
+
+      assert {:ok, %{"path" => "deep/nested/file.md"}} =
+               URITemplate.match(t, "file:///deep/nested/file.md")
+    end
+
+    test "still rejects fragment" do
+      {:ok, t} = URITemplate.parse("file:///{+path}")
+      assert :error = URITemplate.match(t, "file:///foo#frag")
+    end
+  end
+
+  describe "Level 2 — fragment expansion {#var}" do
+    test "matches fragment" do
+      {:ok, t} = URITemplate.parse("/page{#section}")
+      assert {:ok, %{"section" => "intro"}} = URITemplate.match(t, "/page#intro")
+    end
+
+    test "rejects when no fragment present" do
+      {:ok, t} = URITemplate.parse("/page{#section}")
+      assert :error = URITemplate.match(t, "/page")
+    end
+  end
+end


### PR DESCRIPTION
Closes #114

## Problem

No DSL to define MCP resource templates. Parameterized resource URIs (e.g. `file:///{path}`) had no clean way to expose to clients via `resources/templates/list` and no var extraction on `resources/read`.

## Solution

- New `Anubis.Server.Component.URITemplate` module — RFC 6570 Levels 1 and 2 (`{var}`, `{+var}`, `{#var}`) parser and matcher.
- Compile-time validation in `Component.__using__` — rejects templates with invalid syntax and rejects setting both `:uri` and `:uri_template`.
- `resources/read` handler now extracts URI variables and passes them to `read/2` as `%{"uri" => uri, "params" => vars}`.
- Docs example added to `Component.Resource` moduledoc.

## Rationale

Foundation (struct field, `templates/list` handler, JSON encoding) already existed but variable extraction was missing — handlers had to regex-parse URIs manually. L1+L2 covers static paths (`{var}`) and file-style nested paths (`{+path}`); L3/L4 deferred until needed (explode/prefix not generally invertible from URI alone). Plain string in DSL kept over a sigil — same compile-time safety with no new syntax burden.