### PR TITLE
fix: scope POST-with-SSE response to originating conn

### DIFF
--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -246,7 +246,7 @@ if Code.ensure_loaded?(Plug) do
 
       case GenServer.call(session_pid, {:mcp_request, message, context}, opts.timeout) do
         {:ok, response} when is_binary(response) ->
-          route_sse_response(conn, response, session_id, opts)
+          stream_response_on_conn(conn, response, session_id, session_header)
 
         {:ok, nil} ->
           conn
@@ -268,62 +268,26 @@ if Code.ensure_loaded?(Plug) do
         )
     end
 
-    defp route_sse_response(conn, response, session_id, %{transport: transport} = opts) do
-      handler_pid = StreamableHTTP.get_sse_handler(transport, session_id)
+    # Per MCP 2025-06-18 Streamable HTTP: a POST that opts into SSE response
+    # gets its OWN stream on its OWN HTTP connection, scoped to that request.
+    # Stream the response chunk on this conn and let Plug finalize the chunked
+    # response. Never reuse the session-wide SSE handler (GET stream).
+    defp stream_response_on_conn(conn, response, session_id, session_header) do
+      conn = put_resp_header(conn, session_header, session_id)
+      conn = Streaming.prepare_connection(conn)
 
-      cond do
-        handler_pid && Process.alive?(handler_pid) ->
-          ref = make_ref()
-          send(handler_pid, {:sse_message, response, {self(), ref}})
-
-          receive do
-            {^ref, :ok} ->
-              conn
-              |> put_resp_content_type("application/json")
-              |> send_resp(202, "{}")
-
-            {^ref, {:error, _reason}} ->
-              establish_sse_for_request(conn, response, session_id, opts)
-          after
-            5_000 ->
-              establish_sse_for_request(conn, response, session_id, opts)
-          end
-
-        handler_pid ->
-          StreamableHTTP.unregister_sse_handler(transport, session_id, handler_pid)
-          establish_sse_for_request(conn, response, session_id, opts)
-
-        true ->
-          establish_sse_for_request(conn, response, session_id, opts)
-      end
-    end
-
-    defp establish_sse_for_request(conn, response, session_id, opts) do
-      %{transport: transport, session_header: session_header} = opts
-
-      case StreamableHTTP.register_sse_handler(transport, session_id) do
-        :ok ->
-          handler_pid = self()
-          self_pid = self()
-          Task.start(fn -> send(self_pid, {:sse_message, response}) end)
-
+      case Streaming.send_event(conn, response, 0) do
+        {:ok, conn} ->
           conn
-          |> put_resp_header(session_header, session_id)
-          |> Streaming.prepare_connection()
-          |> Streaming.start(transport, session_id,
-            on_close: fn ->
-              StreamableHTTP.unregister_sse_handler(transport, session_id, handler_pid)
-            end
-          )
 
         {:error, reason} ->
-          Logging.transport_event("sse_registration_failed", %{reason: reason}, level: :error)
-
-          send_jsonrpc_error(
-            conn,
-            Error.protocol(:internal_error, %{reason: reason}),
-            nil
+          Logging.transport_event(
+            "sse_post_send_failed",
+            %{session_id: session_id, reason: inspect(reason)},
+            level: :warning
           )
+
+          conn
       end
     end
 

--- a/test/anubis/server/transport/streamable_http/plug_test.exs
+++ b/test/anubis/server/transport/streamable_http/plug_test.exs
@@ -34,6 +34,35 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
     :persistent_term.erase({ServerSupervisor, StubServer, :session_config})
   end
 
+  defp wait_for_sse_handler(transport, session_id, timeout_ms) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    do_wait_for_sse_handler(transport, session_id, deadline)
+  end
+
+  defp do_wait_for_sse_handler(transport, session_id, deadline) do
+    case StreamableHTTP.get_sse_handler(transport, session_id) do
+      nil ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          nil
+        else
+          Process.sleep(10)
+          do_wait_for_sse_handler(transport, session_id, deadline)
+        end
+
+      pid ->
+        pid
+    end
+  end
+
+  defp response_body(%Plug.Conn{resp_body: ""} = conn) do
+    case conn.adapter do
+      {Plug.Adapters.Test.Conn, %{chunks: chunks}} when is_binary(chunks) -> chunks
+      _ -> ""
+    end
+  end
+
+  defp response_body(%Plug.Conn{resp_body: body}) when is_binary(body), do: body
+
   describe "init/1" do
     setup do
       setup_session_config()
@@ -228,6 +257,63 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
       assert conn.status == 400
       {:ok, body} = Jason.decode(conn.resp_body)
       assert body["error"]["code"] == -32_700
+    end
+
+    test "parallel POST-with-SSE responses do not bleed across HTTP connections",
+         %{opts: opts, transport: transport, test_session_id: session_id} do
+      build_post = fn arg, request_id ->
+        request =
+          build_request("tools/call", %{
+            "name" => "greet",
+            "arguments" => %{"name" => arg}
+          })
+
+        {:ok, body} = Message.encode_request(request, request_id)
+
+        :post
+        |> conn("/", body)
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("accept", "application/json, text/event-stream")
+        |> put_req_header("mcp-session-id", session_id)
+      end
+
+      task_a =
+        Task.async(fn ->
+          conn_a = build_post.("ALPHA", "req-A")
+          StreamableHTTPPlug.call(conn_a, opts)
+        end)
+
+      task_b =
+        Task.async(fn ->
+          Process.sleep(50)
+          conn_b = build_post.("BRAVO", "req-B")
+          StreamableHTTPPlug.call(conn_b, opts)
+        end)
+
+      conn_a = Task.await(task_a, 5_000)
+      conn_b = Task.await(task_b, 5_000)
+
+      _ = wait_for_sse_handler(transport, session_id, 0)
+
+      body_a = response_body(conn_a)
+      body_b = response_body(conn_b)
+
+      # Spec (MCP 2025-06-18 §Streamable HTTP):
+      # POST_A's SSE stream is for response_A and traffic related to
+      # request_A only. It MUST NOT carry response_B.
+      assert body_a =~ "Hello ALPHA!", "POST_A's connection should carry response_A"
+
+      refute body_a =~ "Hello BRAVO!",
+             "BUG: POST_B's response was delivered on POST_A's HTTP connection"
+
+      refute body_a =~ "req-B",
+             "BUG: POST_A's connection received an SSE event for request id req-B"
+
+      assert conn_b.status == 200,
+             "POST_B should return its own response on its own connection"
+
+      assert body_b =~ "Hello BRAVO!", "POST_B's connection should carry response_B"
+      assert body_b =~ "req-B"
     end
   end
 


### PR DESCRIPTION
## Problem

Closes #143. Concurrent `tools/call` POSTs with `Accept: text/event-stream` on the same session bleed responses across HTTP connections. POST_B's response can be written on POST_A's chunked conn while POST_B's own conn returns an empty 202 ack. Reporter symptom: "sometimes you might get a result of the previous tool call instead of what you expected".

Race is NOT in tool execution — `Anubis.Server.Session` `handle_call({:mcp_request, ...})` serializes correctly. Race is in response routing. `Anubis.Server.Transport.StreamableHTTP` keeps `sse_handlers :: %{session_id => {pid, ref}}` — single handler slot per session. The first POST-with-SSE registers its own pid into that slot; later POSTs reuse the same slot via `route_sse_response` and forward their response binary to whoever is registered there.

## Solution

POST-initiated SSE streams are scoped to the POST's own connection, never multiplexed through the session-wide handler.

- `handle_sse_request/6` now calls a new `stream_response_on_conn/4` that writes the response chunk on the current `Plug.Conn` and lets Plug finalize the chunked response.
- Removed `route_sse_response/4` and `establish_sse_for_request/4`.
- `StreamableHTTP.sse_handlers` map remains for the GET-initiated server-push channel and broadcast notifications.
- Added regression test `parallel POST-with-SSE responses do not bleed across HTTP connections` in `plug_test.exs` (adapted from duics' reproducer branch).

## Rationale

Per MCP 2025-06-18 Streamable HTTP, a POST that opts into SSE response gets its own stream on its own HTTP connection, scoped to that single request. The GET-initiated SSE channel is the session-wide server-push channel. These are distinct and the implementation now reflects that separation.

The user's intuition that wrapping each tool call in a `Task` would be the wrong fix is correct: tool execution is already serialized by the session GenServer, tasking would not change response routing, and it would introduce state-mutation hazards across concurrent tools. Parallel tool execution remains an orthogonal feature for a separate PR.

Full test suite: 711 tests, 0 failures. Credo + format clean.