### PR TITLE
fix: log sse_keepalive_failed at :warning, matching sse_send_failed

### DIFF
--- a/lib/anubis/sse/streaming.ex
+++ b/lib/anubis/sse/streaming.ex
@@ -84,7 +84,7 @@ if Code.ensure_loaded?(Plug) do
               loop(conn, transport, session_id, event_counter + 1)
 
             {:error, reason} ->
-              Logging.transport_event("sse_keepalive_failed", %{session_id: session_id, reason: reason}, level: :error)
+              Logging.transport_event("sse_keepalive_failed", %{session_id: session_id, reason: reason}, level: :warning)
 
               conn
           end


### PR DESCRIPTION
## Problem

The keepalive branch in `Anubis.SSE.Streaming.loop/4` logs at `:error` when `Plug.Conn.chunk/2` fails, but the only realistic cause is the client having closed the connection — normal SSE lifecycle, not an application error.

The two adjacent branches in the receive loop share the same failure mode and the same `Plug.Conn.chunk/2` call, but were updated inconsistently:

```elixir
:sse_keepalive ->
  case keep_alive(conn) do
    {:ok, conn} -> loop(...)
    {:error, reason} ->
      Logging.transport_event("sse_keepalive_failed",
        %{session_id: session_id, reason: reason}, level: :error)   # still :error
      conn
  end

{:sse_message, message} when is_binary(message) ->
  case send_event(conn, message, event_counter) do
    {:ok, conn} -> loop(...)
    {:error, reason} ->
      Logging.transport_event("sse_send_failed",
        %{session_id: session_id, reason: reason}, level: :warning) # downgraded in #132
      conn
  end
```

## Solution

Lower `sse_keepalive_failed` to `:warning`, matching `sse_send_failed`.

## Rationale

Quoting #132:

> The \`sse_send_failed\` log level is also downgraded from \`:error\` to \`:warning\` — a closed client connection is a normal operational event, not an application error.

That rationale applies symmetrically to the keepalive branch.

## Impact

In production we see this fire ~10 times per 14 minutes across distinct clients on a low-traffic deployment, flooding error trackers and masking real errors.

## Test plan

No tests touched — the existing suite has no coverage of `Streaming.loop/4` log levels, and adding one for a private receive-loop branch would be disproportionate to a one-line change. Validated locally by tailing logs while killing an SSE client mid-keepalive.