### PR TITLE
feat: add resource subscription capability implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ result
 /.lexical/
 /.expert/
 /.elixir-tools/
+.dexter.*
 
 # macOS
 **/.DS_Store

--- a/lib/anubis/client.ex
+++ b/lib/anubis/client.ex
@@ -422,6 +422,52 @@ defmodule Anubis.Client do
   end
 
   @doc """
+  Subscribes to updates for a specific resource URI.
+
+  After a successful subscribe, the server may send `notifications/resources/updated`
+  notifications for this URI. The server must declare the `resources.subscribe`
+  capability for this method to succeed.
+
+  ## Options
+
+    * `:timeout` - Request timeout in milliseconds
+  """
+  @spec subscribe_resource(t, String.t(), keyword) ::
+          {:ok, Response.t()} | {:error, Error.t()}
+  def subscribe_resource(client, uri, opts \\ []) do
+    operation =
+      Operation.new(%{
+        method: "resources/subscribe",
+        params: %{"uri" => uri},
+        timeout: Keyword.get(opts, :timeout, @default_operation_timeout)
+      })
+
+    buffer_timeout = operation.timeout + to_timeout(second: 1)
+    GenServer.call(client, {:operation, operation}, buffer_timeout)
+  end
+
+  @doc """
+  Unsubscribes from updates for a previously-subscribed resource URI.
+
+  ## Options
+
+    * `:timeout` - Request timeout in milliseconds
+  """
+  @spec unsubscribe_resource(t, String.t(), keyword) ::
+          {:ok, Response.t()} | {:error, Error.t()}
+  def unsubscribe_resource(client, uri, opts \\ []) do
+    operation =
+      Operation.new(%{
+        method: "resources/unsubscribe",
+        params: %{"uri" => uri},
+        timeout: Keyword.get(opts, :timeout, @default_operation_timeout)
+      })
+
+    buffer_timeout = operation.timeout + to_timeout(second: 1)
+    GenServer.call(client, {:operation, operation}, buffer_timeout)
+  end
+
+  @doc """
   Lists available prompts from the server.
 
   ## Options

--- a/lib/anubis/client/state.ex
+++ b/lib/anubis/client/state.ex
@@ -658,7 +658,7 @@ defmodule Anubis.Client.State do
 
   defp valid_capability?(capabilities, ["resources", sub]) when sub in ~w(subscribe unsubscribe) do
     if resources = Map.get(capabilities, "resources") do
-      valid_capability?(resources, [sub, nil])
+      Map.get(resources, "subscribe") == true
     end
   end
 

--- a/lib/anubis/client/state.ex
+++ b/lib/anubis/client/state.ex
@@ -657,8 +657,9 @@ defmodule Anubis.Client.State do
   defp valid_capability?(_capabilities, ["roots", "list"]), do: true
 
   defp valid_capability?(capabilities, ["resources", sub]) when sub in ~w(subscribe unsubscribe) do
-    if resources = Map.get(capabilities, "resources") do
-      Map.get(resources, "subscribe") == true
+    case Map.get(capabilities, "resources") do
+      %{} = resources -> Map.get(resources, "subscribe") == true
+      _ -> false
     end
   end
 

--- a/lib/anubis/mcp/message.ex
+++ b/lib/anubis/mcp/message.ex
@@ -28,6 +28,14 @@ defmodule Anubis.MCP.Message do
     "uri" => {:required, :string}
   }
 
+  @resources_subscribe_params_schema %{
+    "uri" => {:required, :string}
+  }
+
+  @resources_unsubscribe_params_schema %{
+    "uri" => {:required, :string}
+  }
+
   @prompts_list_params_schema %{
     "cursor" => :string
   }
@@ -125,6 +133,8 @@ defmodule Anubis.MCP.Message do
     "resources/list" => Map.merge(@resources_list_params_schema, @progress_params),
     "resources/templates/list" => :map,
     "resources/read" => Map.merge(@resources_read_params_schema, @progress_params),
+    "resources/subscribe" => Map.merge(@resources_subscribe_params_schema, @progress_params),
+    "resources/unsubscribe" => Map.merge(@resources_unsubscribe_params_schema, @progress_params),
     "prompts/list" => Map.merge(@prompts_list_params_schema, @progress_params),
     "prompts/get" => Map.merge(@prompts_get_params_schema, @progress_params),
     "tools/list" => Map.merge(@tools_list_params_schema, @progress_params),
@@ -183,7 +193,10 @@ defmodule Anubis.MCP.Message do
     "notifications/message" => @logging_message_notif_params_schema,
     "notifications/roots/list_changed" => :map,
     "notifications/log/message" => :map,
-    "notifications/tools/list_changed" => :map
+    "notifications/tools/list_changed" => :map,
+    "notifications/prompts/list_changed" => :map,
+    "notifications/resources/list_changed" => :map,
+    "notifications/resources/updated" => :map
   }
 
   @notification_branches Map.new(@notification_branch_specs, fn {method, params_schema} ->

--- a/lib/anubis/mcp/message.ex
+++ b/lib/anubis/mcp/message.ex
@@ -186,6 +186,10 @@ defmodule Anubis.MCP.Message do
     "logger" => :string
   }
 
+  @resource_updated_notif_params_schema %{
+    "uri" => {:required, :string}
+  }
+
   @notification_branch_specs %{
     "notifications/initialized" => @init_noti_params_schema,
     "notifications/cancelled" => @cancel_noti_params_schema,
@@ -196,7 +200,7 @@ defmodule Anubis.MCP.Message do
     "notifications/tools/list_changed" => :map,
     "notifications/prompts/list_changed" => :map,
     "notifications/resources/list_changed" => :map,
-    "notifications/resources/updated" => :map
+    "notifications/resources/updated" => @resource_updated_notif_params_schema
   }
 
   @notification_branches Map.new(@notification_branch_specs, fn {method, params_schema} ->

--- a/lib/anubis/protocol/v2024_11_05.ex
+++ b/lib/anubis/protocol/v2024_11_05.ex
@@ -30,6 +30,7 @@ defmodule Anubis.Protocol.V2024_11_05 do
   @request_methods ~w(
     initialize ping
     resources/list resources/templates/list resources/read
+    resources/subscribe resources/unsubscribe
     prompts/get prompts/list
     tools/call tools/list
     logging/setLevel completion/complete
@@ -41,6 +42,9 @@ defmodule Anubis.Protocol.V2024_11_05 do
     notifications/progress notifications/message
     notifications/roots/list_changed notifications/log/message
     notifications/tools/list_changed
+    notifications/prompts/list_changed
+    notifications/resources/list_changed
+    notifications/resources/updated
   )
 
   @progress_params_schema %{
@@ -80,6 +84,8 @@ defmodule Anubis.Protocol.V2024_11_05 do
   def request_params_schema("resources/list"), do: %{"cursor" => :string}
   def request_params_schema("resources/templates/list"), do: %{"cursor" => :string}
   def request_params_schema("resources/read"), do: %{"uri" => {:required, :string}}
+  def request_params_schema("resources/subscribe"), do: %{"uri" => {:required, :string}}
+  def request_params_schema("resources/unsubscribe"), do: %{"uri" => {:required, :string}}
   def request_params_schema("prompts/list"), do: %{"cursor" => :string}
 
   def request_params_schema("prompts/get") do

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -607,13 +607,17 @@ defmodule Anubis.Server do
   @doc """
   Sends a resource updated notification for a specific resource.
 
+  Subscription-gated: only emits if the current session has previously
+  received a `resources/subscribe` request for this URI. Calls for
+  unsubscribed URIs are silently dropped.
+
   **Must be called from within a Session callback** — see `send_resources_list_changed/0` for details.
   """
   @spec send_resource_updated(uri :: String.t(), timestamp :: DateTime.t() | nil) :: :ok
   def send_resource_updated(uri, timestamp \\ nil) do
     params = %{"uri" => uri}
     params = if timestamp, do: Map.put(params, "timestamp", timestamp), else: params
-    send(self(), {:send_notification, "notifications/resources/updated", params})
+    send(self(), {:send_resource_update, uri, params})
     :ok
   end
 

--- a/lib/anubis/server/frame.ex
+++ b/lib/anubis/server/frame.ex
@@ -337,14 +337,23 @@ defmodule Anubis.Server.Frame do
   """
   @spec from_saved(map()) :: t()
   def from_saved(map) when is_map(map) do
+    subs =
+      map
+      |> Map.get("resource_subscriptions", [])
+      |> Enum.filter(&is_binary/1)
+      |> build_subscriptions()
+
     %__MODULE__{
       assigns: Map.get(map, "assigns", %{}),
       pagination_limit: Map.get(map, "pagination_limit"),
-      resource_subscriptions: map |> Map.get("resource_subscriptions", []) |> MapSet.new()
+      resource_subscriptions: subs
     }
   end
 
-  def from_saved(_), do: %__MODULE__{}
+  def from_saved(_), do: %__MODULE__{resource_subscriptions: build_subscriptions([])}
+
+  @spec build_subscriptions([String.t()]) :: MapSet.t(String.t())
+  defp build_subscriptions(list), do: MapSet.new(list)
 end
 
 defimpl Inspect, for: Anubis.Server.Frame do

--- a/lib/anubis/server/frame.ex
+++ b/lib/anubis/server/frame.ex
@@ -40,6 +40,7 @@ defmodule Anubis.Server.Frame do
           resources: %{optional(String.t()) => Resource.t()},
           prompts: %{optional(String.t()) => Prompt.t()},
           resource_templates: %{optional(String.t()) => Resource.t()},
+          resource_subscriptions: MapSet.t(String.t()),
           pagination_limit: non_neg_integer() | nil,
           context: Context.t()
         }
@@ -49,6 +50,7 @@ defmodule Anubis.Server.Frame do
             resources: %{},
             prompts: %{},
             resource_templates: %{},
+            resource_subscriptions: MapSet.new(),
             pagination_limit: nil,
             context: %Context{}
 
@@ -239,6 +241,30 @@ defmodule Anubis.Server.Frame do
     %{frame | resource_templates: Map.put(frame.resource_templates, name, resource)}
   end
 
+  @doc """
+  Records that this session has subscribed to updates for the given resource
+  URI.
+
+  Idempotent — subscribing twice to the same URI is a no-op. Per the MCP spec,
+  the URI does not need to refer to a currently-registered resource.
+  """
+  @spec subscribe_resource(t(), uri :: String.t()) :: t()
+  def subscribe_resource(%__MODULE__{} = frame, uri) when is_binary(uri) do
+    %{frame | resource_subscriptions: MapSet.put(frame.resource_subscriptions, uri)}
+  end
+
+  @doc "Removes a previously-recorded subscription for the given URI."
+  @spec unsubscribe_resource(t(), uri :: String.t()) :: t()
+  def unsubscribe_resource(%__MODULE__{} = frame, uri) when is_binary(uri) do
+    %{frame | resource_subscriptions: MapSet.delete(frame.resource_subscriptions, uri)}
+  end
+
+  @doc "Returns whether this session has an active subscription for the given URI."
+  @spec resource_subscribed?(t(), uri :: String.t()) :: boolean()
+  def resource_subscribed?(%__MODULE__{} = frame, uri) when is_binary(uri) do
+    MapSet.member?(frame.resource_subscriptions, uri)
+  end
+
   @doc "Clears all runtime-registered components"
   @spec clear_components(t()) :: t()
   def clear_components(%__MODULE__{} = frame) do
@@ -296,23 +322,25 @@ defmodule Anubis.Server.Frame do
   def to_saved(%__MODULE__{} = frame) do
     %{
       "assigns" => frame.assigns,
-      "pagination_limit" => frame.pagination_limit
+      "pagination_limit" => frame.pagination_limit,
+      "resource_subscriptions" => MapSet.to_list(frame.resource_subscriptions)
     }
   end
 
   @doc """
   Reconstructs Frame from a previously saved map.
 
-  Only `assigns` and `pagination_limit` are restored. Runtime-only fields (`tools`,
-  `resources`, `prompts`, `resource_templates`) are initialized empty — their validator
-  functions are not serializable. `context` is left as the default struct and will be
-  set by Session before each callback invocation.
+  Restored: `assigns`, `pagination_limit`, `resource_subscriptions`. Runtime-only fields
+  (`tools`, `resources`, `prompts`, `resource_templates`) are initialized empty — their
+  validator functions are not serializable. `context` is left as the default struct and
+  will be set by Session before each callback invocation.
   """
   @spec from_saved(map()) :: t()
   def from_saved(map) when is_map(map) do
     %__MODULE__{
       assigns: Map.get(map, "assigns", %{}),
-      pagination_limit: Map.get(map, "pagination_limit")
+      pagination_limit: Map.get(map, "pagination_limit"),
+      resource_subscriptions: map |> Map.get("resource_subscriptions", []) |> MapSet.new()
     }
   end
 
@@ -328,7 +356,8 @@ defimpl Inspect, for: Anubis.Server.Frame do
       tools: map_size(frame.tools),
       resources: map_size(frame.resources),
       prompts: map_size(frame.prompts),
-      resource_templates: map_size(frame.resource_templates)
+      resource_templates: map_size(frame.resource_templates),
+      resource_subscriptions: MapSet.size(frame.resource_subscriptions)
     ]
 
     info =

--- a/lib/anubis/server/handlers.ex
+++ b/lib/anubis/server/handlers.ex
@@ -17,6 +17,7 @@ defmodule Anubis.Server.Handlers do
     case action do
       "list" -> Tools.handle_list(request, frame, module)
       "call" -> Tools.handle_call(request, frame, module)
+      _ -> {:error, Error.protocol(:method_not_found, %{method: request["method"]}), frame}
     end
   end
 
@@ -24,6 +25,7 @@ defmodule Anubis.Server.Handlers do
     case action do
       "list" -> Prompts.handle_list(request, frame, module)
       "get" -> Prompts.handle_get(request, frame, module)
+      _ -> {:error, Error.protocol(:method_not_found, %{method: request["method"]}), frame}
     end
   end
 
@@ -32,6 +34,9 @@ defmodule Anubis.Server.Handlers do
       "list" -> Resources.handle_list(request, frame, module)
       "read" -> Resources.handle_read(request, frame, module)
       "templates/list" -> Resources.handle_templates_list(request, frame, module)
+      "subscribe" -> Resources.handle_subscribe(request, frame, module)
+      "unsubscribe" -> Resources.handle_unsubscribe(request, frame, module)
+      _ -> {:error, Error.protocol(:method_not_found, %{method: request["method"]}), frame}
     end
   end
 

--- a/lib/anubis/server/handlers/resources.ex
+++ b/lib/anubis/server/handlers/resources.ex
@@ -51,7 +51,31 @@ defmodule Anubis.Server.Handlers.Resources do
     end
   end
 
+  @spec handle_subscribe(map(), Frame.t(), module()) ::
+          {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
+  def handle_subscribe(%{"params" => %{"uri" => uri}}, frame, server) when is_binary(uri) do
+    if subscribe_enabled?(server) do
+      {:reply, %{}, Frame.subscribe_resource(frame, uri)}
+    else
+      {:error, Error.protocol(:method_not_found, %{method: "resources/subscribe"}), frame}
+    end
+  end
+
+  @spec handle_unsubscribe(map(), Frame.t(), module()) ::
+          {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
+  def handle_unsubscribe(%{"params" => %{"uri" => uri}}, frame, server) when is_binary(uri) do
+    if subscribe_enabled?(server) do
+      {:reply, %{}, Frame.unsubscribe_resource(frame, uri)}
+    else
+      {:error, Error.protocol(:method_not_found, %{method: "resources/unsubscribe"}), frame}
+    end
+  end
+
   # Private functions
+
+  defp subscribe_enabled?(server) do
+    get_in(server.server_capabilities(), ["resources", :subscribe]) == true
+  end
 
   defp find_static_resource(resources, uri), do: Enum.find(resources, &(&1.uri == uri))
 

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -321,6 +321,16 @@ defmodule Anubis.Server.Session do
     end
   end
 
+  def handle_info({:send_resource_update, uri, params}, state) do
+    subscribed? = Frame.resource_subscribed?(state.frame, uri)
+
+    if subscribed? do
+      send(self(), {:send_notification, "notifications/resources/updated", params})
+    end
+
+    {:noreply, state}
+  end
+
   def handle_info(:session_expired, state) do
     Logging.server_event("session_expired", %{session_id: state.session_id})
     {:stop, {:shutdown, :session_expired}, state}

--- a/test/anubis/client_test.exs
+++ b/test/anubis/client_test.exs
@@ -936,14 +936,14 @@ defmodule Anubis.ClientTest do
         nil
       )
 
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
       send_notification(
         client,
         build_notification("notifications/resources/updated", %{"uri" => "file:///x"})
       )
 
       assert_receive {:client_notification, %{method: "resources/updated", uri: "file:///x"}}, 200
-
-      :telemetry.detach(handler_id)
     end
   end
 

--- a/test/anubis/client_test.exs
+++ b/test/anubis/client_test.exs
@@ -220,6 +220,72 @@ defmodule Anubis.ClientTest do
       assert response.is_error == false
     end
 
+    @tag server_capabilities: %{"resources" => %{"subscribe" => true}, "tools" => %{}, "prompts" => %{}}
+    test "subscribe_resource sends correct request", %{client: client} do
+      test_pid = self()
+
+      expect(Anubis.MockTransport, :send_message, fn _, message, _ ->
+        send(test_pid, {:request_sent, JSON.decode!(message)})
+        :ok
+      end)
+
+      task =
+        Task.async(fn -> Anubis.Client.subscribe_resource(client, "file:///watched") end)
+
+      assert_receive {:request_sent, decoded}, 200
+      assert decoded["method"] == "resources/subscribe"
+      assert decoded["params"] == %{"uri" => "file:///watched"}
+      assert decoded["jsonrpc"] == "2.0"
+      assert is_binary(decoded["id"])
+
+      send_response(client, build_response(%{}, decoded["id"]))
+
+      assert {:ok, %Response{result: %{}}} = Task.await(task)
+    end
+
+    @tag server_capabilities: %{"resources" => %{"subscribe" => true}, "tools" => %{}, "prompts" => %{}}
+    test "unsubscribe_resource sends correct request", %{client: client} do
+      test_pid = self()
+
+      expect(Anubis.MockTransport, :send_message, fn _, message, _ ->
+        send(test_pid, {:request_sent, JSON.decode!(message)})
+        :ok
+      end)
+
+      task =
+        Task.async(fn -> Anubis.Client.unsubscribe_resource(client, "file:///watched") end)
+
+      assert_receive {:request_sent, decoded}, 200
+      assert decoded["method"] == "resources/unsubscribe"
+      assert decoded["params"] == %{"uri" => "file:///watched"}
+
+      send_response(client, build_response(%{}, decoded["id"]))
+
+      assert {:ok, %Response{result: %{}}} = Task.await(task)
+    end
+
+    @tag server_capabilities: %{"resources" => %{}, "tools" => %{}, "prompts" => %{}}
+    test "subscribe_resource fails when server did not declare subscribe capability",
+         %{client: client} do
+      task =
+        Task.async(fn -> Anubis.Client.subscribe_resource(client, "file:///x") end)
+
+      assert {:error,
+              %Error{reason: :method_not_found, data: %{method: "resources/subscribe"}}} =
+               Task.await(task)
+    end
+
+    @tag server_capabilities: %{"resources" => %{}, "tools" => %{}, "prompts" => %{}}
+    test "unsubscribe_resource fails when server did not declare subscribe capability",
+         %{client: client} do
+      task =
+        Task.async(fn -> Anubis.Client.unsubscribe_resource(client, "file:///x") end)
+
+      assert {:error,
+              %Error{reason: :method_not_found, data: %{method: "resources/unsubscribe"}}} =
+               Task.await(task)
+    end
+
     test "list_prompts sends correct request", %{client: client} do
       test_pid = self()
 
@@ -849,6 +915,37 @@ defmodule Anubis.ClientTest do
       state = :sys.get_state(client)
       assert state.server_info
       assert state.server_capabilities
+    end
+  end
+
+  describe "resource update notifications" do
+    setup :initialized_client
+
+    test "handles notifications/resources/updated", %{client: client} do
+      # The client's notification handler logs + emits telemetry; success here
+      # means (1) the dispatcher recognized the method, (2) the Peri schema
+      # accepted the payload (regression for the missing-method bug we fixed),
+      # and (3) the URI made it through to the metadata.
+      test_pid = self()
+      handler_id = "test-resource-updated-#{System.unique_integer()}"
+
+      :telemetry.attach(
+        handler_id,
+        [:anubis_mcp | Anubis.Telemetry.event_client_notification()],
+        fn _event, _measurements, metadata, _config ->
+          send(test_pid, {:client_notification, metadata})
+        end,
+        nil
+      )
+
+      send_notification(
+        client,
+        build_notification("notifications/resources/updated", %{"uri" => "file:///x"})
+      )
+
+      assert_receive {:client_notification, %{method: "resources/updated", uri: "file:///x"}}, 200
+
+      :telemetry.detach(handler_id)
     end
   end
 

--- a/test/anubis/client_test.exs
+++ b/test/anubis/client_test.exs
@@ -270,8 +270,7 @@ defmodule Anubis.ClientTest do
       task =
         Task.async(fn -> Anubis.Client.subscribe_resource(client, "file:///x") end)
 
-      assert {:error,
-              %Error{reason: :method_not_found, data: %{method: "resources/subscribe"}}} =
+      assert {:error, %Error{reason: :method_not_found, data: %{method: "resources/subscribe"}}} =
                Task.await(task)
     end
 
@@ -281,8 +280,7 @@ defmodule Anubis.ClientTest do
       task =
         Task.async(fn -> Anubis.Client.unsubscribe_resource(client, "file:///x") end)
 
-      assert {:error,
-              %Error{reason: :method_not_found, data: %{method: "resources/unsubscribe"}}} =
+      assert {:error, %Error{reason: :method_not_found, data: %{method: "resources/unsubscribe"}}} =
                Task.await(task)
     end
 

--- a/test/anubis/mcp/message_test.exs
+++ b/test/anubis/mcp/message_test.exs
@@ -103,6 +103,67 @@ defmodule Anubis.MCP.MessageTest do
       assert {:ok, _} = Message.validate_message(msg)
     end
 
+    test "validates resources/subscribe request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "resources/subscribe",
+        "id" => 1,
+        "params" => %{"uri" => "file:///watched"}
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates resources/unsubscribe request" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "resources/unsubscribe",
+        "id" => 1,
+        "params" => %{"uri" => "file:///watched"}
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "rejects resources/subscribe request missing uri" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "resources/subscribe",
+        "id" => 1,
+        "params" => %{}
+      }
+
+      assert {:error, _} = Message.validate_message(msg)
+    end
+
+    test "validates notifications/resources/updated notification" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/resources/updated",
+        "params" => %{"uri" => "file:///x"}
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates notifications/resources/list_changed notification" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/resources/list_changed"
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
+    test "validates notifications/prompts/list_changed notification" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/prompts/list_changed"
+      }
+
+      assert {:ok, _} = Message.validate_message(msg)
+    end
+
     test "validates cancelled notification" do
       msg = %{
         "jsonrpc" => "2.0",

--- a/test/anubis/mcp/message_test.exs
+++ b/test/anubis/mcp/message_test.exs
@@ -146,6 +146,16 @@ defmodule Anubis.MCP.MessageTest do
       assert {:ok, _} = Message.validate_message(msg)
     end
 
+    test "rejects notifications/resources/updated notification missing uri" do
+      msg = %{
+        "jsonrpc" => "2.0",
+        "method" => "notifications/resources/updated",
+        "params" => %{}
+      }
+
+      assert {:error, _} = Message.validate_message(msg)
+    end
+
     test "validates notifications/resources/list_changed notification" do
       msg = %{
         "jsonrpc" => "2.0",

--- a/test/anubis/server/frame_test.exs
+++ b/test/anubis/server/frame_test.exs
@@ -102,4 +102,96 @@ defmodule Anubis.Server.FrameTest do
       assert Enum.any?(resources, &(&1.name == "second"))
     end
   end
+
+  describe "subscribe_resource/2" do
+    test "records a subscription for the given URI" do
+      frame = Frame.subscribe_resource(Frame.new(), "file:///foo")
+
+      assert Frame.resource_subscribed?(frame, "file:///foo")
+    end
+
+    test "is idempotent — subscribing twice keeps a single entry" do
+      frame =
+        Frame.new()
+        |> Frame.subscribe_resource("file:///foo")
+        |> Frame.subscribe_resource("file:///foo")
+
+      assert MapSet.size(frame.resource_subscriptions) == 1
+    end
+
+    test "URIs do not need to refer to a registered resource" do
+      frame = Frame.subscribe_resource(Frame.new(), "does-not-exist:///x")
+
+      assert Frame.resource_subscribed?(frame, "does-not-exist:///x")
+    end
+  end
+
+  describe "unsubscribe_resource/2" do
+    test "removes an existing subscription" do
+      frame =
+        Frame.new()
+        |> Frame.subscribe_resource("file:///foo")
+        |> Frame.unsubscribe_resource("file:///foo")
+
+      refute Frame.resource_subscribed?(frame, "file:///foo")
+    end
+
+    test "is a no-op for a URI that was not subscribed" do
+      frame = Frame.unsubscribe_resource(Frame.new(), "file:///never-subscribed")
+
+      assert MapSet.size(frame.resource_subscriptions) == 0
+    end
+
+    test "leaves other subscriptions intact" do
+      frame =
+        Frame.new()
+        |> Frame.subscribe_resource("file:///a")
+        |> Frame.subscribe_resource("file:///b")
+        |> Frame.unsubscribe_resource("file:///a")
+
+      refute Frame.resource_subscribed?(frame, "file:///a")
+      assert Frame.resource_subscribed?(frame, "file:///b")
+    end
+  end
+
+  describe "resource_subscribed?/2" do
+    test "returns false for an empty frame" do
+      refute Frame.resource_subscribed?(Frame.new(), "file:///foo")
+    end
+
+    test "returns true for a subscribed URI" do
+      frame = Frame.subscribe_resource(Frame.new(), "file:///foo")
+
+      assert Frame.resource_subscribed?(frame, "file:///foo")
+    end
+  end
+
+  describe "to_saved/1 and from_saved/1 round-trip" do
+    test "preserves subscriptions across persistence" do
+      frame =
+        Frame.new()
+        |> Frame.subscribe_resource("file:///a")
+        |> Frame.subscribe_resource("file:///b")
+
+      restored = frame |> Frame.to_saved() |> Frame.from_saved()
+
+      assert Frame.resource_subscribed?(restored, "file:///a")
+      assert Frame.resource_subscribed?(restored, "file:///b")
+    end
+
+    test "serializes subscriptions as a list (JSON-friendly)" do
+      frame = Frame.subscribe_resource(Frame.new(), "file:///x")
+
+      saved = Frame.to_saved(frame)
+
+      assert is_list(saved["resource_subscriptions"])
+      assert "file:///x" in saved["resource_subscriptions"]
+    end
+
+    test "from_saved/1 restores an empty MapSet when key is missing" do
+      restored = Frame.from_saved(%{"assigns" => %{}})
+
+      assert restored.resource_subscriptions == MapSet.new()
+    end
+  end
 end

--- a/test/anubis/server/handlers_test.exs
+++ b/test/anubis/server/handlers_test.exs
@@ -52,6 +52,18 @@ defmodule Anubis.Server.HandlersTest do
     end
   end
 
+  defmodule SubscribingServer do
+    @moduledoc false
+    def __components__(:resource), do: []
+    def server_capabilities, do: %{"resources" => %{subscribe: true}}
+  end
+
+  defmodule NonSubscribingServer do
+    @moduledoc false
+    def __components__(:resource), do: []
+    def server_capabilities, do: %{"resources" => %{}}
+  end
+
   describe "maybe_paginate/3" do
     test "returns all items when limit is nil" do
       components = [
@@ -527,6 +539,77 @@ defmodule Anubis.Server.HandlersTest do
       assert_raise ArgumentError, fn ->
         Handlers.handle(request, MockServer, frame)
       end
+    end
+  end
+
+  describe "resources/subscribe routing" do
+    test "subscribes when capability is declared" do
+      request = %{"method" => "resources/subscribe", "params" => %{"uri" => "file:///x"}}
+
+      assert {:reply, %{}, frame} = Handlers.handle(request, SubscribingServer, Frame.new())
+      assert Frame.resource_subscribed?(frame, "file:///x")
+    end
+
+    test "returns method_not_found when capability is not declared" do
+      request = %{"method" => "resources/subscribe", "params" => %{"uri" => "file:///x"}}
+
+      assert {:error, error, _frame} =
+               Handlers.handle(request, NonSubscribingServer, Frame.new())
+
+      assert error.code == -32_601
+    end
+
+    test "subscribing to a URI not registered as a resource still succeeds" do
+      request = %{"method" => "resources/subscribe", "params" => %{"uri" => "ghost:///nowhere"}}
+
+      assert {:reply, %{}, frame} = Handlers.handle(request, SubscribingServer, Frame.new())
+      assert Frame.resource_subscribed?(frame, "ghost:///nowhere")
+    end
+  end
+
+  describe "resources/unsubscribe routing" do
+    test "removes a previously-recorded subscription" do
+      starting_frame = Frame.subscribe_resource(Frame.new(), "file:///x")
+      request = %{"method" => "resources/unsubscribe", "params" => %{"uri" => "file:///x"}}
+
+      assert {:reply, %{}, frame} =
+               Handlers.handle(request, SubscribingServer, starting_frame)
+
+      refute Frame.resource_subscribed?(frame, "file:///x")
+    end
+
+    test "returns method_not_found when capability is not declared" do
+      request = %{"method" => "resources/unsubscribe", "params" => %{"uri" => "file:///x"}}
+
+      assert {:error, error, _frame} =
+               Handlers.handle(request, NonSubscribingServer, Frame.new())
+
+      assert error.code == -32_601
+    end
+  end
+
+  describe "unknown sub-action routing (Phase 0 regression)" do
+    test "resources/<unknown> returns method_not_found instead of crashing" do
+      request = %{"method" => "resources/foo", "params" => %{}}
+
+      assert {:error, error, _frame} =
+               Handlers.handle(request, SubscribingServer, Frame.new())
+
+      assert error.code == -32_601
+    end
+
+    test "tools/<unknown> returns method_not_found instead of crashing" do
+      request = %{"method" => "tools/nonexistent", "params" => %{}}
+
+      assert {:error, error, _frame} = Handlers.handle(request, MockServer, Frame.new())
+      assert error.code == -32_601
+    end
+
+    test "prompts/<unknown> returns method_not_found instead of crashing" do
+      request = %{"method" => "prompts/nope", "params" => %{}}
+
+      assert {:error, error, _frame} = Handlers.handle(request, MockServer, Frame.new())
+      assert error.code == -32_601
     end
   end
 end

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -2,6 +2,7 @@ defmodule Anubis.Server.SessionTest do
   use Anubis.MCP.Case, async: false
 
   alias Anubis.MCP.Message
+  alias Anubis.Server.Frame
   alias Anubis.Server.Registry
   alias Anubis.Server.Session
 
@@ -111,6 +112,57 @@ defmodule Anubis.Server.SessionTest do
 
                  :ok
                end)
+    end
+  end
+
+  describe "send_resource_updated subscription gating" do
+    setup :initialized_server
+
+    test "emits notification when URI is subscribed", %{server: session, transport: transport} do
+      :ok = StubTransport.set_test_pid(transport, self())
+
+      :sys.replace_state(session, fn state ->
+        %{state | frame: Frame.subscribe_resource(state.frame, "file:///watched")}
+      end)
+
+      send(session, {:send_resource_update, "file:///watched", %{"uri" => "file:///watched"}})
+
+      assert_receive {:send_message, data}, 200
+      assert {:ok, [decoded]} = Message.decode(data)
+      assert decoded["method"] == "notifications/resources/updated"
+      assert decoded["params"]["uri"] == "file:///watched"
+    end
+
+    test "drops notification silently when URI is not subscribed", %{
+      server: session,
+      transport: transport
+    } do
+      :ok = StubTransport.set_test_pid(transport, self())
+
+      send(session, {:send_resource_update, "file:///not-watched", %{"uri" => "file:///not-watched"}})
+
+      refute_receive {:send_message, _}, 100
+    end
+
+    test "Server.send_resource_updated/2 routes through the gate", %{
+      server: session,
+      transport: transport
+    } do
+      :ok = StubTransport.set_test_pid(transport, self())
+
+      # :sys.replace_state runs its callback inside the session process,
+      # so self() inside the helper resolves to the session pid — the
+      # condition send_resource_updated/2 requires of its callers.
+      :sys.replace_state(session, fn state ->
+        new_frame = Frame.subscribe_resource(state.frame, "file:///watched")
+        Anubis.Server.send_resource_updated("file:///watched")
+        %{state | frame: new_frame}
+      end)
+
+      assert_receive {:send_message, data}, 200
+      assert {:ok, [decoded]} = Message.decode(data)
+      assert decoded["method"] == "notifications/resources/updated"
+      assert decoded["params"]["uri"] == "file:///watched"
     end
   end
 


### PR DESCRIPTION
## Problem

https://github.com/zoedsoupe/anubis-mcp/issues/148

Clients couldn't subscribe to resources according to the MCP spec

## Solution

Wire up the rest of the `subscribe` workflow for `resources.` 

## Rationale

I saw the half implementation- making `capabilities` support a `resources/subscribe`, but was confused about the rest of the implementation not being wired up.

## Documents
Frame includes `resouce_subscriptions`
<img width="341" height="207" alt="image" src="https://github.com/user-attachments/assets/e445a89f-bbc2-41f3-9686-375409ace05a" />
Frame can subscribe to resources
<img width="533" height="265" alt="image" src="https://github.com/user-attachments/assets/5d6e36fe-a2a9-4710-98c7-1b1b79c8e268" />
Frame can be encoded/decoded with subscriptions in tact
<img width="430" height="191" alt="image" src="https://github.com/user-attachments/assets/5b1d1574-c355-4a57-91ff-76309c3b17c1" />



