### PR TITLE
feat: dispatch session requests in supervised tasks

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -57,7 +57,19 @@ defmodule Anubis.Server.Session do
             }
           },
           timeout: pos_integer(),
-          task_supervisor: GenServer.name()
+          task_supervisor: GenServer.name(),
+          in_flight:
+            nil
+            | %{
+                ref: reference(),
+                pid: pid(),
+                request_id: String.t(),
+                from: GenServer.from(),
+                started_at: integer(),
+                method: String.t()
+              },
+          request_queue: :queue.queue({map(), map(), GenServer.from()}),
+          deferred_callbacks: :queue.queue({:cast | :info, term()})
         }
 
   defschema(:parse_options, [
@@ -142,7 +154,10 @@ defmodule Anubis.Server.Session do
       pending_requests: %{},
       server_requests: %{},
       timeout: opts.timeout,
-      task_supervisor: opts.task_supervisor
+      task_supervisor: opts.task_supervisor,
+      in_flight: nil,
+      request_queue: :queue.new(),
+      deferred_callbacks: :queue.new()
     }
 
     state = schedule_session_expiry(state)
@@ -170,11 +185,11 @@ defmodule Anubis.Server.Session do
   # Request/Response handling
 
   @impl GenServer
-  def handle_call({:mcp_request, decoded, transport_context}, _from, state) when is_map(decoded) do
+  def handle_call({:mcp_request, decoded, transport_context}, from, state) when is_map(decoded) do
     state = merge_transport_assigns(state, transport_context)
     state = reset_session_expiry(state)
 
-    handle_single_request(decoded, transport_context, state)
+    handle_single_request(decoded, transport_context, from, state)
   end
 
   def handle_call(:auto_initialize, _from, %{initialized: true} = state) do
@@ -254,7 +269,38 @@ defmodule Anubis.Server.Session do
   # Notification dispatch
 
   @impl GenServer
-  def handle_cast({:mcp_notification, decoded, transport_context}, state) when is_map(decoded) do
+  def handle_cast({:mcp_notification, decoded, _ctx} = msg, %{in_flight: f} = state)
+      when not is_nil(f) and is_map(decoded) do
+    if cancellation_notification?(decoded) do
+      process_mcp_notification(msg, state)
+    else
+      {:noreply, defer_callback(state, {:cast, msg})}
+    end
+  end
+
+  def handle_cast({:mcp_notification, decoded, _ctx} = msg, state) when is_map(decoded) do
+    process_mcp_notification(msg, state)
+  end
+
+  # Server-initiated request responses (sampling/roots)
+
+  def handle_cast({:mcp_response, decoded, _ctx} = msg, %{in_flight: f} = state) when not is_nil(f) and is_map(decoded) do
+    {:noreply, defer_callback(state, {:cast, msg})}
+  end
+
+  def handle_cast({:mcp_response, decoded, _context}, state) when is_map(decoded) do
+    process_mcp_response(decoded, state)
+  end
+
+  def handle_cast(request, %{in_flight: f} = state) when not is_nil(f) do
+    {:noreply, defer_callback(state, {:cast, request})}
+  end
+
+  def handle_cast(request, state) do
+    process_user_cast(request, state)
+  end
+
+  defp process_mcp_notification({:mcp_notification, decoded, transport_context}, state) do
     state = merge_transport_assigns(state, transport_context)
     state = reset_session_expiry(state)
 
@@ -271,9 +317,7 @@ defmodule Anubis.Server.Session do
     end
   end
 
-  # Server-initiated request responses (sampling/roots)
-
-  def handle_cast({:mcp_response, decoded, _context}, state) when is_map(decoded) do
+  defp process_mcp_response(decoded, state) do
     cond do
       Message.is_response(decoded) and server_request?(decoded["id"], state) ->
         handle_server_request_response(decoded, state)
@@ -292,11 +336,28 @@ defmodule Anubis.Server.Session do
     end
   end
 
-  def handle_cast(request, %{server_module: module} = state) do
+  defp cancellation_notification?(%{"method" => "notifications/cancelled"}), do: true
+  defp cancellation_notification?(_), do: false
+
+  defp process_user_cast(request, %{server_module: module} = state) do
     if Anubis.exported?(module, :handle_cast, 2) do
       frame = prepare_frame(state)
 
       case module.handle_cast(request, frame) do
+        {:noreply, frame} -> {:noreply, %{state | frame: frame}}
+        {:noreply, frame, cont} -> {:noreply, %{state | frame: frame}, cont}
+        {:stop, reason, frame} -> {:stop, reason, %{state | frame: frame}}
+      end
+    else
+      {:noreply, state}
+    end
+  end
+
+  defp process_user_info(event, %{server_module: module} = state) do
+    if Anubis.exported?(module, :handle_info, 2) do
+      frame = prepare_frame(state)
+
+      case module.handle_info(event, frame) do
         {:noreply, frame} -> {:noreply, %{state | frame: frame}}
         {:noreply, frame, cont} -> {:noreply, %{state | frame: frame}, cont}
         {:stop, reason, frame} -> {:stop, reason, %{state | frame: frame}}
@@ -353,23 +414,55 @@ defmodule Anubis.Server.Session do
     handle_elicitation_timeout(request_id, state)
   end
 
-  def handle_info(event, %{server_module: module} = state) do
-    if Anubis.exported?(module, :handle_info, 2) do
-      frame = prepare_frame(state)
+  def handle_info({ref, callback_result}, %{in_flight: %{ref: ref} = inflight} = state) do
+    Process.demonitor(ref, [:flush])
+    {reply, state} = decode_task_result(callback_result, inflight, state)
+    state = complete_request(%{state | in_flight: nil}, inflight.request_id)
+    GenServer.reply(inflight.from, reply)
 
-      case module.handle_info(event, frame) do
-        {:noreply, frame} -> {:noreply, %{state | frame: frame}}
-        {:noreply, frame, cont} -> {:noreply, %{state | frame: frame}, cont}
-        {:stop, reason, frame} -> {:stop, reason, %{state | frame: frame}}
-      end
-    else
-      {:noreply, state}
-    end
+    state
+    |> drain_deferred_callbacks()
+    |> dispatch_next_queued()
+    |> noreply()
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, reason}, %{in_flight: %{ref: ref} = inflight} = state) do
+    Logging.server_event(
+      "request_task_crashed",
+      %{request_id: inflight.request_id, method: inflight.method, reason: inspect(reason)},
+      level: :error
+    )
+
+    Telemetry.execute(
+      Telemetry.event_server_error(),
+      %{system_time: System.system_time()},
+      %{id: inflight.request_id, method: inflight.method, error: reason}
+    )
+
+    error = Error.protocol(:internal_error, %{message: "Tool execution crashed"})
+    reply = {:ok, encode_reply(Error.build_json_rpc(error, inflight.request_id))}
+
+    state = complete_request(%{state | in_flight: nil}, inflight.request_id)
+    GenServer.reply(inflight.from, reply)
+
+    state
+    |> drain_deferred_callbacks()
+    |> dispatch_next_queued()
+    |> noreply()
+  end
+
+  def handle_info(event, %{in_flight: f} = state) when not is_nil(f) do
+    {:noreply, defer_callback(state, {:info, event})}
+  end
+
+  def handle_info(event, state) do
+    process_user_info(event, state)
   end
 
   @impl GenServer
   def terminate(reason, %{server_module: module, server_info: server_info} = state) do
     cancel_session_expiry(state)
+    reply_to_pending_callers(state, reason)
 
     Logging.server_event("session_terminating", %{
       session_id: state.session_id,
@@ -389,6 +482,24 @@ defmodule Anubis.Server.Session do
     else
       :ok
     end
+  end
+
+  defp reply_to_pending_callers(%{in_flight: in_flight, request_queue: q}, reason) do
+    error =
+      Error.protocol(:internal_error, %{
+        message: "Session terminating",
+        reason: inspect(reason)
+      })
+
+    if in_flight do
+      reply = {:ok, encode_reply(Error.build_json_rpc(error, in_flight.request_id))}
+      GenServer.reply(in_flight.from, reply)
+    end
+
+    Enum.each(:queue.to_list(q), fn {%{"id" => request_id}, _ctx, from} ->
+      reply = {:ok, encode_reply(Error.build_json_rpc(error, request_id))}
+      GenServer.reply(from, reply)
+    end)
   end
 
   @impl GenServer
@@ -417,13 +528,15 @@ defmodule Anubis.Server.Session do
             when Message.is_initialize_lifecycle(decoded) or
                    state.initialized == true
 
-  defp handle_single_request(decoded, transport_context, state) do
+  defp handle_single_request(decoded, transport_context, from, state) do
     cond do
       Message.is_response(decoded) and server_request?(decoded["id"], state) ->
-        handle_server_request_response(decoded, state)
+        {:noreply, new_state} = handle_server_request_response(decoded, state)
+        {:reply, {:ok, nil}, new_state}
 
       Message.is_error(decoded) and server_request?(decoded["id"], state) ->
-        handle_server_request_error(decoded, state)
+        {:noreply, new_state} = handle_server_request_error(decoded, state)
+        {:reply, {:ok, nil}, new_state}
 
       Message.is_ping(decoded) ->
         handle_server_ping(decoded, state)
@@ -432,7 +545,7 @@ defmodule Anubis.Server.Session do
         handle_server_not_initialized(state)
 
       Message.is_request(decoded) ->
-        handle_request(decoded, transport_context, state)
+        handle_request(decoded, transport_context, from, state)
 
       true ->
         handle_invalid_request(state)
@@ -466,7 +579,8 @@ defmodule Anubis.Server.Session do
 
   # Initialize handling
 
-  defp handle_request(%{"params" => params} = request, _transport_context, state) when Message.is_initialize(request) do
+  defp handle_request(%{"params" => params} = request, _transport_context, _from, state)
+       when Message.is_initialize(request) do
     %{
       "clientInfo" => client_info,
       "capabilities" => client_capabilities,
@@ -508,14 +622,26 @@ defmodule Anubis.Server.Session do
     {:reply, {:ok, encode_reply(Message.build_response(result, request["id"]))}, state}
   end
 
-  defp handle_request(%{"id" => request_id, "method" => "logging/setLevel"} = request, _transport_context, state)
+  defp handle_request(%{"id" => request_id, "method" => "logging/setLevel"} = request, _transport_context, _from, state)
        when Server.is_supported_capability(state.capabilities, "logging") do
     level = request["params"]["level"]
     state = %{state | log_level: level}
     {:reply, {:ok, encode_reply(Message.build_response(%{}, request_id))}, state}
   end
 
-  defp handle_request(%{"id" => request_id, "method" => method} = request, transport_context, state) do
+  defp handle_request(%{"id" => _, "method" => _} = request, transport_context, from, state) do
+    enqueue_or_dispatch(request, transport_context, from, state)
+  end
+
+  defp enqueue_or_dispatch(request, ctx, from, %{in_flight: nil} = state) do
+    {:noreply, dispatch_request(request, ctx, from, state)}
+  end
+
+  defp enqueue_or_dispatch(request, ctx, from, state) do
+    {:noreply, %{state | request_queue: :queue.in({request, ctx, from}, state.request_queue)}}
+  end
+
+  defp dispatch_request(%{"id" => request_id, "method" => method} = request, transport_context, from, state) do
     Logging.server_event("handling_request", %{
       id: request_id,
       method: method,
@@ -531,8 +657,118 @@ defmodule Anubis.Server.Session do
     )
 
     frame = prepare_frame(state, transport_context)
-    server_request(request, %{state | frame: frame})
+    module = state.server_module
+
+    task =
+      Task.Supervisor.async_nolink(state.task_supervisor, fn ->
+        do_handle_request(module, request, frame, method)
+      end)
+
+    %{
+      state
+      | in_flight: %{
+          ref: task.ref,
+          pid: task.pid,
+          request_id: request_id,
+          from: from,
+          started_at: System.system_time(:millisecond),
+          method: method
+        }
+    }
   end
+
+  defp do_handle_request(module, %{"method" => "tools/call"} = request, frame, _method) do
+    tool_name = get_in(request, ["params", "name"])
+
+    :telemetry.span(
+      Telemetry.event_server_tool_call(),
+      %{tool: tool_name},
+      fn -> {module.handle_request(request, frame), %{tool: tool_name}} end
+    )
+  end
+
+  defp do_handle_request(module, request, frame, _method) do
+    module.handle_request(request, frame)
+  end
+
+  # Async dispatch helpers
+
+  defp decode_task_result({:reply, response, %Frame{} = frame}, inflight, state) do
+    Telemetry.execute(
+      Telemetry.event_server_response(),
+      %{system_time: System.system_time()},
+      %{id: inflight.request_id, method: inflight.method, status: :success}
+    )
+
+    reply = {:ok, encode_reply(Message.build_response(response, inflight.request_id))}
+    {reply, %{state | frame: frame}}
+  end
+
+  defp decode_task_result({:noreply, %Frame{} = frame}, inflight, state) do
+    Telemetry.execute(
+      Telemetry.event_server_response(),
+      %{system_time: System.system_time()},
+      %{id: inflight.request_id, method: inflight.method, status: :noreply}
+    )
+
+    {{:ok, nil}, %{state | frame: frame}}
+  end
+
+  defp decode_task_result({:error, %Error{} = error, %Frame{} = frame}, inflight, state) do
+    Logging.server_event(
+      "request_error",
+      %{id: inflight.request_id, method: inflight.method, error: error},
+      level: :warning
+    )
+
+    Telemetry.execute(
+      Telemetry.event_server_error(),
+      %{system_time: System.system_time()},
+      %{id: inflight.request_id, method: inflight.method, error: error}
+    )
+
+    reply = {:ok, encode_reply(Error.build_json_rpc(error, inflight.request_id))}
+    {reply, %{state | frame: frame}}
+  end
+
+  defp defer_callback(state, item) do
+    %{state | deferred_callbacks: :queue.in(item, state.deferred_callbacks)}
+  end
+
+  defp drain_deferred_callbacks(%{deferred_callbacks: q} = state) do
+    state = %{state | deferred_callbacks: :queue.new()}
+    Enum.reduce(:queue.to_list(q), state, &apply_deferred/2)
+  end
+
+  defp apply_deferred({:cast, msg}, state) do
+    msg |> dispatch_deferred_cast(state) |> unwrap_state()
+  end
+
+  defp apply_deferred({:info, msg}, state) do
+    msg |> process_user_info(state) |> unwrap_state()
+  end
+
+  defp dispatch_deferred_cast({:mcp_notification, _, _} = msg, state), do: process_mcp_notification(msg, state)
+
+  defp dispatch_deferred_cast({:mcp_response, decoded, _ctx}, state), do: process_mcp_response(decoded, state)
+
+  defp dispatch_deferred_cast(other, state), do: process_user_cast(other, state)
+
+  defp unwrap_state({:noreply, state}), do: state
+  defp unwrap_state({:noreply, state, _cont}), do: state
+  defp unwrap_state({:stop, _reason, state}), do: state
+
+  defp dispatch_next_queued(%{request_queue: q} = state) do
+    case :queue.out(q) do
+      {:empty, _} ->
+        state
+
+      {{:value, {request, ctx, from}}, rest} ->
+        dispatch_request(request, ctx, from, %{state | request_queue: rest})
+    end
+  end
+
+  defp noreply(state), do: {:noreply, state}
 
   # Notification handling
 
@@ -567,36 +803,19 @@ defmodule Anubis.Server.Session do
     request_id = params["requestId"]
     reason = Map.get(params, "reason", "cancelled")
 
-    case Map.get(state.pending_requests, request_id) do
-      nil ->
+    cond do
+      in_flight?(state, request_id) ->
+        cancel_in_flight(state, request_id, reason)
+
+      queued?(state, request_id) ->
+        cancel_queued(state, request_id, reason)
+
+      true ->
         Logging.server_event("cancellation_for_unknown_request", %{
           session_id: state.session_id,
           request_id: request_id,
           reason: reason
         })
-
-        {:noreply, state}
-
-      request_info ->
-        state = complete_request(state, request_id)
-
-        Logging.server_event("request_cancelled", %{
-          session_id: state.session_id,
-          request_id: request_id,
-          reason: reason,
-          method: request_info[:method],
-          duration_ms: System.system_time(:millisecond) - request_info[:started_at]
-        })
-
-        Telemetry.execute(
-          Telemetry.event_server_notification(),
-          %{system_time: System.system_time()},
-          %{
-            method: "cancelled",
-            session_id: state.session_id,
-            request_id: request_id
-          }
-        )
 
         {:noreply, state}
     end
@@ -617,49 +836,70 @@ defmodule Anubis.Server.Session do
     server_notification(notification, %{state | frame: frame})
   end
 
-  # Server request/notification dispatch
+  defp in_flight?(%{in_flight: %{request_id: rid}}, rid), do: true
+  defp in_flight?(_, _), do: false
 
-  defp server_request(%{"id" => request_id, "method" => method} = request, %{server_module: module} = state) do
-    case module.handle_request(request, state.frame) do
-      {:reply, response, %Frame{} = frame} ->
-        Telemetry.execute(
-          Telemetry.event_server_response(),
-          %{system_time: System.system_time()},
-          %{id: request_id, method: method, status: :success}
-        )
-
-        state = complete_request(%{state | frame: frame}, request_id)
-
-        {:reply, {:ok, encode_reply(Message.build_response(response, request_id))}, state}
-
-      {:noreply, %Frame{} = frame} ->
-        Telemetry.execute(
-          Telemetry.event_server_response(),
-          %{system_time: System.system_time()},
-          %{id: request_id, method: method, status: :noreply}
-        )
-
-        state = complete_request(%{state | frame: frame}, request_id)
-        {:reply, {:ok, nil}, state}
-
-      {:error, %Error{} = error, %Frame{} = frame} ->
-        Logging.server_event(
-          "request_error",
-          %{id: request_id, method: method, error: error},
-          level: :warning
-        )
-
-        Telemetry.execute(
-          Telemetry.event_server_error(),
-          %{system_time: System.system_time()},
-          %{id: request_id, method: method, error: error}
-        )
-
-        state = complete_request(%{state | frame: frame}, request_id)
-
-        {:reply, {:ok, encode_reply(Error.build_json_rpc(error, request_id))}, state}
-    end
+  defp queued?(%{request_queue: q}, rid) do
+    Enum.any?(:queue.to_list(q), fn {%{"id" => id}, _ctx, _from} -> id == rid end)
   end
+
+  defp cancel_in_flight(%{in_flight: inflight} = state, request_id, reason) do
+    Task.Supervisor.terminate_child(state.task_supervisor, inflight.pid)
+    Process.demonitor(inflight.ref, [:flush])
+
+    Logging.server_event("request_cancelled", %{
+      session_id: state.session_id,
+      request_id: request_id,
+      reason: reason,
+      method: inflight.method,
+      duration_ms: System.system_time(:millisecond) - inflight.started_at
+    })
+
+    emit_cancellation_telemetry(state.session_id, request_id)
+
+    error = Error.execution("Request cancelled", %{reason: reason})
+    reply = {:ok, encode_reply(Error.build_json_rpc(error, request_id))}
+    GenServer.reply(inflight.from, reply)
+
+    state = complete_request(%{state | in_flight: nil}, request_id)
+
+    state
+    |> drain_deferred_callbacks()
+    |> dispatch_next_queued()
+    |> noreply()
+  end
+
+  defp cancel_queued(state, request_id, reason) do
+    {cancelled, kept} =
+      state.request_queue
+      |> :queue.to_list()
+      |> Enum.split_with(fn {%{"id" => id}, _ctx, _from} -> id == request_id end)
+
+    error = Error.execution("Request cancelled", %{reason: reason})
+    reply = {:ok, encode_reply(Error.build_json_rpc(error, request_id))}
+
+    Enum.each(cancelled, fn {_request, _ctx, from} -> GenServer.reply(from, reply) end)
+
+    Logging.server_event("queued_request_cancelled", %{
+      session_id: state.session_id,
+      request_id: request_id,
+      reason: reason
+    })
+
+    emit_cancellation_telemetry(state.session_id, request_id)
+
+    {:noreply, %{state | request_queue: :queue.from_list(kept)}}
+  end
+
+  defp emit_cancellation_telemetry(session_id, request_id) do
+    Telemetry.execute(
+      Telemetry.event_server_notification(),
+      %{system_time: System.system_time()},
+      %{method: "cancelled", session_id: session_id, request_id: request_id}
+    )
+  end
+
+  # Notification dispatch to user module
 
   defp server_notification(%{"method" => method} = notification, %{server_module: module} = state) do
     if Anubis.exported?(module, :handle_notification, 2) do

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -421,10 +421,7 @@ defmodule Anubis.Server.Session do
     state = complete_request(%{state | in_flight: nil}, inflight.request_id)
     GenServer.reply(inflight.from, reply)
 
-    state
-    |> drain_deferred_callbacks()
-    |> dispatch_next_queued()
-    |> noreply()
+    finalize_after_task(state)
   end
 
   def handle_info({:DOWN, ref, :process, _pid, reason}, %{in_flight: %{ref: ref} = inflight} = state) do
@@ -446,10 +443,7 @@ defmodule Anubis.Server.Session do
     state = complete_request(%{state | in_flight: nil}, inflight.request_id)
     GenServer.reply(inflight.from, reply)
 
-    state
-    |> drain_deferred_callbacks()
-    |> dispatch_next_queued()
-    |> noreply()
+    finalize_after_task(state)
   end
 
   def handle_info(event, %{in_flight: f} = state) when not is_nil(f) do
@@ -485,7 +479,7 @@ defmodule Anubis.Server.Session do
     end
   end
 
-  defp reply_to_pending_callers(%{in_flight: in_flight, request_queue: q}, reason) do
+  defp reply_to_pending_callers(%{in_flight: in_flight, request_queue: q, task_supervisor: task_supervisor}, reason) do
     error =
       Error.protocol(:internal_error, %{
         message: "Session terminating",
@@ -493,6 +487,10 @@ defmodule Anubis.Server.Session do
       })
 
     if in_flight do
+      Task.Supervisor.terminate_child(task_supervisor, in_flight.pid)
+      Process.demonitor(in_flight.ref, [:flush])
+      flush_task_reply(in_flight.ref)
+
       reply = {:ok, encode_reply(Error.build_json_rpc(error, in_flight.request_id))}
       GenServer.reply(in_flight.from, reply)
     end
@@ -764,26 +762,27 @@ defmodule Anubis.Server.Session do
 
   defp drain_deferred_callbacks(%{deferred_callbacks: q} = state) do
     state = %{state | deferred_callbacks: :queue.new()}
-    Enum.reduce(:queue.to_list(q), state, &apply_deferred/2)
+
+    Enum.reduce_while(:queue.to_list(q), state, fn item, acc ->
+      case apply_deferred(item, acc) do
+        {:noreply, new_state} -> {:cont, new_state}
+        {:noreply, new_state, _cont} -> {:cont, new_state}
+        {:stop, _reason, _new_state} = stop -> {:halt, stop}
+      end
+    end)
   end
 
-  defp apply_deferred({:cast, msg}, state) do
-    msg |> dispatch_deferred_cast(state) |> unwrap_state()
+  defp apply_deferred({:cast, {:mcp_notification, _, _} = msg}, state), do: process_mcp_notification(msg, state)
+  defp apply_deferred({:cast, {:mcp_response, decoded, _ctx}}, state), do: process_mcp_response(decoded, state)
+  defp apply_deferred({:cast, msg}, state), do: process_user_cast(msg, state)
+  defp apply_deferred({:info, msg}, state), do: process_user_info(msg, state)
+
+  defp finalize_after_task(state) do
+    case drain_deferred_callbacks(state) do
+      {:stop, _reason, _new_state} = stop -> stop
+      new_state -> new_state |> dispatch_next_queued() |> noreply()
+    end
   end
-
-  defp apply_deferred({:info, msg}, state) do
-    msg |> process_user_info(state) |> unwrap_state()
-  end
-
-  defp dispatch_deferred_cast({:mcp_notification, _, _} = msg, state), do: process_mcp_notification(msg, state)
-
-  defp dispatch_deferred_cast({:mcp_response, decoded, _ctx}, state), do: process_mcp_response(decoded, state)
-
-  defp dispatch_deferred_cast(other, state), do: process_user_cast(other, state)
-
-  defp unwrap_state({:noreply, state}), do: state
-  defp unwrap_state({:noreply, state, _cont}), do: state
-  defp unwrap_state({:stop, _reason, state}), do: state
 
   defp dispatch_next_queued(%{request_queue: q} = state) do
     case :queue.out(q) do
@@ -890,11 +889,7 @@ defmodule Anubis.Server.Session do
     GenServer.reply(inflight.from, reply)
 
     state = complete_request(%{state | in_flight: nil}, request_id)
-
-    state
-    |> drain_deferred_callbacks()
-    |> dispatch_next_queued()
-    |> noreply()
+    finalize_after_task(state)
   end
 
   defp cancel_queued(state, request_id, reason) do

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -336,7 +336,8 @@ defmodule Anubis.Server.Session do
     end
   end
 
-  defp cancellation_notification?(%{"method" => "notifications/cancelled"}), do: true
+  defp cancellation_notification?(%{"method" => "notifications/cancelled"} = msg), do: Message.is_notification(msg)
+
   defp cancellation_notification?(_), do: false
 
   defp process_user_cast(request, %{server_module: module} = state) do
@@ -671,10 +672,18 @@ defmodule Anubis.Server.Session do
           pid: task.pid,
           request_id: request_id,
           from: from,
-          started_at: System.system_time(:millisecond),
+          started_at: System.monotonic_time(:millisecond),
           method: method
         }
     }
+  end
+
+  defp flush_task_reply(ref) do
+    receive do
+      {^ref, _result} -> :ok
+    after
+      0 -> :ok
+    end
   end
 
   defp do_handle_request(module, %{"method" => "tools/call"} = request, frame, _method) do
@@ -729,6 +738,24 @@ defmodule Anubis.Server.Session do
 
     reply = {:ok, encode_reply(Error.build_json_rpc(error, inflight.request_id))}
     {reply, %{state | frame: frame}}
+  end
+
+  defp decode_task_result(other, inflight, state) do
+    Logging.server_event(
+      "invalid_handle_request_return",
+      %{id: inflight.request_id, method: inflight.method, returned: inspect(other)},
+      level: :error
+    )
+
+    Telemetry.execute(
+      Telemetry.event_server_error(),
+      %{system_time: System.system_time()},
+      %{id: inflight.request_id, method: inflight.method, error: :invalid_return}
+    )
+
+    error = Error.protocol(:internal_error, %{message: "Invalid handler return value"})
+    reply = {:ok, encode_reply(Error.build_json_rpc(error, inflight.request_id))}
+    {reply, state}
   end
 
   defp defer_callback(state, item) do
@@ -846,13 +873,14 @@ defmodule Anubis.Server.Session do
   defp cancel_in_flight(%{in_flight: inflight} = state, request_id, reason) do
     Task.Supervisor.terminate_child(state.task_supervisor, inflight.pid)
     Process.demonitor(inflight.ref, [:flush])
+    flush_task_reply(inflight.ref)
 
     Logging.server_event("request_cancelled", %{
       session_id: state.session_id,
       request_id: request_id,
       reason: reason,
       method: inflight.method,
-      duration_ms: System.system_time(:millisecond) - inflight.started_at
+      duration_ms: System.monotonic_time(:millisecond) - inflight.started_at
     })
 
     emit_cancellation_telemetry(state.session_id, request_id)

--- a/test/anubis/server/session_async_dispatch_test.exs
+++ b/test/anubis/server/session_async_dispatch_test.exs
@@ -90,6 +90,26 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
       assert {:ok, encoded2} = GenServer.call(session, {:mcp_request, followup, ctx}, 5_000)
       assert tool_text(encoded2) == "alive"
     end
+
+    test "malformed handler return becomes internal_error, session survives", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("malformed_return", %{}, "bad-1")
+        send(caller, {:reply, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:reply, {:ok, encoded}}, 1_000
+      decoded = decode_one(encoded)
+      assert decoded["error"]["code"] == -32_603
+      assert decoded["error"]["data"]["message"] == "Invalid handler return value"
+      assert Process.alive?(session)
+
+      followup = tool_call_request("echo", %{"value" => "still-alive"}, "ok-2")
+      assert {:ok, encoded2} = GenServer.call(session, {:mcp_request, followup, ctx}, 5_000)
+      assert tool_text(encoded2) == "still-alive"
+    end
   end
 
   describe "cancel queued request" do
@@ -195,6 +215,7 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
   defp start_async_session(_ctx) do
     session_id = "async-#{System.unique_integer([:positive])}"
     transport_name = Registry.transport_name(AsyncDispatchTestServer, StubTransport)
+    # StubTransport (not MockTransport) — captures outbound frames and exposes clear/1 for isolation
     transport = start_supervised!({StubTransport, name: transport_name}, id: {:transport, session_id})
     task_sup = Registry.task_supervisor_name(AsyncDispatchTestServer)
 

--- a/test/anubis/server/session_async_dispatch_test.exs
+++ b/test/anubis/server/session_async_dispatch_test.exs
@@ -1,0 +1,246 @@
+defmodule Anubis.Server.SessionAsyncDispatchTest do
+  use Anubis.MCP.Case, async: false
+
+  alias Anubis.MCP.Message
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Session
+  alias Anubis.Test.SyncHelpers
+
+  @moduletag capture_log: true
+
+  setup :start_async_session
+
+  describe "mailbox unblock" do
+    test "cancellation aborts in-flight tool task and replies", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        request = tool_call_request("wait_signal", %{"signal" => "alpha"}, "req-1")
+        result = GenServer.call(session, {:mcp_request, request, ctx}, 5_000)
+        send(caller, {:tool_reply, result})
+      end)
+
+      assert_receive {:tool_running, tool_pid, :alpha}, 1_000
+      assert Process.alive?(tool_pid)
+
+      cancellation = cancelled_notification("req-1", "user requested abort")
+      :ok = GenServer.cast(session, {:mcp_notification, cancellation, ctx})
+
+      assert_receive {:tool_reply, {:ok, encoded}}, 500
+      decoded = decode_one(encoded)
+      assert decoded["error"]["message"] == "Request cancelled"
+      assert decoded["error"]["data"]["reason"] == "user requested abort"
+
+      ref = Process.monitor(tool_pid)
+      assert_receive {:DOWN, ^ref, :process, _, _}, 500
+    end
+  end
+
+  describe "FIFO ordering of queued requests" do
+    test "queued requests reply in arrival order and observe accumulated frame state", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "first"}, "id-1")
+        send(caller, {:reply, 1, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:tool_running, blocker_pid, :first}, 1_000
+
+      for n <- 2..4 do
+        Task.start(fn ->
+          req = tool_call_request("increment", %{}, "id-#{n}")
+          send(caller, {:reply, n, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+        end)
+      end
+
+      SyncHelpers.await_state(session, &(:queue.len(&1.request_queue) == 3))
+
+      send(blocker_pid, {:proceed, :first})
+
+      assert_receive {:reply, 1, {:ok, _}}, 1_000
+      assert_receive {:reply, 2, {:ok, e2}}, 1_000
+      assert_receive {:reply, 3, {:ok, e3}}, 1_000
+      assert_receive {:reply, 4, {:ok, e4}}, 1_000
+
+      assert tool_text(e2) == "count=1"
+      assert tool_text(e3) == "count=2"
+      assert tool_text(e4) == "count=3"
+    end
+  end
+
+  describe "crash isolation" do
+    test "tool crash returns internal_error and session keeps serving", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("crash", %{}, "boom-1")
+        send(caller, {:reply, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:reply, {:ok, encoded}}, 1_000
+      decoded = decode_one(encoded)
+      assert decoded["error"]["code"] == -32_603
+      assert Process.alive?(session)
+
+      followup = tool_call_request("echo", %{"value" => "alive"}, "ok-1")
+      assert {:ok, encoded2} = GenServer.call(session, {:mcp_request, followup, ctx}, 5_000)
+      assert tool_text(encoded2) == "alive"
+    end
+  end
+
+  describe "cancel queued request" do
+    test "queued request is removed and replied without executing", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "blocker"}, "block-1")
+        send(caller, {:reply, :blocker, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:tool_running, blocker_pid, :blocker}, 1_000
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "queued"}, "queued-1")
+        send(caller, {:reply, :queued, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      SyncHelpers.await_state(session, &(:queue.len(&1.request_queue) == 1))
+
+      cancellation = cancelled_notification("queued-1", "abort queued")
+      :ok = GenServer.cast(session, {:mcp_notification, cancellation, ctx})
+
+      assert_receive {:reply, :queued, {:ok, encoded}}, 500
+      decoded = decode_one(encoded)
+      assert decoded["error"]["data"]["reason"] == "abort queued"
+      refute_received {:tool_running, _, :queued}
+
+      send(blocker_pid, {:proceed, :blocker})
+      assert_receive {:reply, :blocker, {:ok, _}}, 1_000
+    end
+  end
+
+  describe "deferred competing frame writers" do
+    test "sampling response is deferred until in-flight tool completes", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "tool"}, "t-1")
+        send(caller, {:reply, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:tool_running, tool_pid, :tool}, 1_000
+
+      :sys.replace_state(session, fn state ->
+        timer_ref = Process.send_after(session, {:sampling_request_timeout, "samp-1"}, 30_000)
+
+        put_in(state.server_requests["samp-1"], %{
+          method: "sampling/createMessage",
+          session_id: state.session_id,
+          timer_ref: timer_ref
+        })
+      end)
+
+      sampling_response = %{
+        "id" => "samp-1",
+        "result" => %{"role" => "assistant", "content" => %{"type" => "text", "text" => "ok"}}
+      }
+
+      :ok = GenServer.cast(session, {:mcp_response, sampling_response, %{}})
+
+      SyncHelpers.await_state(session, &(:queue.len(&1.deferred_callbacks) == 1))
+      refute_received {:sampling_handled, _, _, _}
+
+      send(tool_pid, {:proceed, :tool})
+
+      assert_receive {:reply, {:ok, _}}, 1_000
+      assert_receive {:sampling_handled, "samp-1", %{"role" => "assistant"}, _}, 1_000
+    end
+  end
+
+  describe "session terminate" do
+    test "queued and in-flight requests get internal_error reply on shutdown", %{session: session} do
+      caller = self()
+      ctx = with_test_pid()
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "blocker2"}, "term-block")
+        send(caller, {:reply, :blocker, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      assert_receive {:tool_running, _pid, :blocker2}, 1_000
+
+      Task.start(fn ->
+        req = tool_call_request("wait_signal", %{"signal" => "queued2"}, "term-queued")
+        send(caller, {:reply, :queued, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
+      end)
+
+      SyncHelpers.await_state(session, &(:queue.len(&1.request_queue) == 1))
+
+      :ok = GenServer.stop(session, :shutdown, 1_000)
+
+      assert_receive {:reply, :blocker, {:ok, encoded_blocker}}, 1_000
+      assert_receive {:reply, :queued, {:ok, encoded_queued}}, 1_000
+
+      assert decode_one(encoded_blocker)["error"]["code"] == -32_603
+      assert decode_one(encoded_queued)["error"]["code"] == -32_603
+    end
+  end
+
+  defp start_async_session(_ctx) do
+    session_id = "async-#{System.unique_integer([:positive])}"
+    transport_name = Registry.transport_name(AsyncDispatchTestServer, StubTransport)
+    transport = start_supervised!({StubTransport, name: transport_name}, id: {:transport, session_id})
+    task_sup = Registry.task_supervisor_name(AsyncDispatchTestServer)
+
+    if is_nil(Process.whereis(task_sup)) do
+      start_supervised!({Task.Supervisor, name: task_sup}, id: {:tasksup, session_id})
+    end
+
+    session_name = Registry.session_name(AsyncDispatchTestServer, session_id)
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: session_id,
+         server_module: AsyncDispatchTestServer,
+         name: session_name,
+         transport: [layer: StubTransport, name: transport_name],
+         task_supervisor: task_sup},
+        id: {:session, session_id}
+      )
+
+    request = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"}, %{"sampling" => %{}})
+    {:ok, _} = GenServer.call(session, {:mcp_request, request, with_test_pid()})
+
+    init_notif = build_notification("notifications/initialized", %{})
+    :ok = GenServer.cast(session, {:mcp_notification, init_notif, with_test_pid()})
+
+    SyncHelpers.await_state(session, & &1.initialized)
+    StubTransport.clear(transport)
+
+    %{session: session, transport: transport, session_id: session_id, task_sup: task_sup}
+  end
+
+  defp with_test_pid, do: %{assigns: %{test_pid: self()}}
+
+  defp tool_call_request(name, args, id) do
+    build_request("tools/call", %{"name" => name, "arguments" => args}, id)
+  end
+
+  defp decode_one(encoded) do
+    {:ok, [decoded]} = Message.decode(encoded)
+    decoded
+  end
+
+  defp tool_text(encoded) do
+    decoded = decode_one(encoded)
+    [%{"text" => text}] = decoded["result"]["content"]
+    text
+  end
+end

--- a/test/anubis/server/session_async_dispatch_test.exs
+++ b/test/anubis/server/session_async_dispatch_test.exs
@@ -184,7 +184,7 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
   end
 
   describe "session terminate" do
-    test "queued and in-flight requests get internal_error reply on shutdown", %{session: session} do
+    test "queued and in-flight requests get internal_error reply on shutdown", %{session: session, task_sup: task_sup} do
       caller = self()
       ctx = with_test_pid()
 
@@ -193,7 +193,8 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
         send(caller, {:reply, :blocker, GenServer.call(session, {:mcp_request, req, ctx}, 5_000)})
       end)
 
-      assert_receive {:tool_running, _pid, :blocker2}, 1_000
+      assert_receive {:tool_running, blocker_pid, :blocker2}, 1_000
+      ref = Process.monitor(blocker_pid)
 
       Task.start(fn ->
         req = tool_call_request("wait_signal", %{"signal" => "queued2"}, "term-queued")
@@ -209,6 +210,10 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
 
       assert decode_one(encoded_blocker)["error"]["code"] == -32_603
       assert decode_one(encoded_queued)["error"]["code"] == -32_603
+
+      # In-flight task pid was terminated, not left running on the per-server task_supervisor
+      assert_receive {:DOWN, ^ref, :process, _, _}, 500
+      refute blocker_pid in Task.Supervisor.children(task_sup)
     end
   end
 

--- a/test/support/async_dispatch_test_server.ex
+++ b/test/support/async_dispatch_test_server.ex
@@ -48,6 +48,11 @@ defmodule AsyncDispatchTestServer do
         "properties" => %{"value" => %{"type" => "string"}},
         "required" => ["value"]
       }
+    },
+    %{
+      "name" => "malformed_return",
+      "description" => "returns an invalid handler tuple",
+      "inputSchema" => %{"type" => "object", "properties" => %{}}
     }
   ]
 
@@ -111,6 +116,10 @@ defmodule AsyncDispatchTestServer do
 
   defp handle_tool("crash", _args, _frame) do
     raise "intentional crash from AsyncDispatchTestServer"
+  end
+
+  defp handle_tool("malformed_return", _args, _frame) do
+    :not_a_valid_handler_return
   end
 
   defp handle_tool("echo", %{"value" => value}, frame) do

--- a/test/support/async_dispatch_test_server.ex
+++ b/test/support/async_dispatch_test_server.ex
@@ -1,0 +1,126 @@
+defmodule AsyncDispatchTestServer do
+  @moduledoc """
+  Test server with controllable tool timing for async dispatch tests.
+
+  Tools:
+    * `wait_signal` — sends `{:tool_running, self(), signal}` to `frame.assigns[:test_pid]`,
+      then blocks on `receive {:proceed, ^signal}`. Lets tests inspect mid-flight state.
+    * `increment` — reads/writes `frame.assigns[:counter]`. Verifies FIFO frame ordering.
+    * `crash` — raises. Verifies async crash isolation.
+    * `echo` — returns the input verbatim. Verifies session survives a previous crash.
+  """
+
+  use Anubis.Server,
+    name: "Async Dispatch Test",
+    version: "1.0.0",
+    capabilities: [:tools]
+
+  import Anubis.Server.Frame, only: [assign: 3]
+
+  alias Anubis.MCP.Error
+  alias Anubis.Server.Response
+
+  @tools [
+    %{
+      "name" => "wait_signal",
+      "description" => "wait for signal from test pid",
+      "inputSchema" => %{
+        "type" => "object",
+        "properties" => %{"signal" => %{"type" => "string"}},
+        "required" => ["signal"]
+      }
+    },
+    %{
+      "name" => "increment",
+      "description" => "increment frame counter",
+      "inputSchema" => %{"type" => "object", "properties" => %{}}
+    },
+    %{
+      "name" => "crash",
+      "description" => "raise an exception",
+      "inputSchema" => %{"type" => "object", "properties" => %{}}
+    },
+    %{
+      "name" => "echo",
+      "description" => "echo a string value",
+      "inputSchema" => %{
+        "type" => "object",
+        "properties" => %{"value" => %{"type" => "string"}},
+        "required" => ["value"]
+      }
+    }
+  ]
+
+  @impl true
+  def handle_request(%{"method" => "ping"}, frame), do: {:reply, %{}, frame}
+
+  def handle_request(%{"method" => "tools/list"}, frame) do
+    {:reply, %{"tools" => @tools, "nextCursor" => nil}, frame}
+  end
+
+  def handle_request(%{"method" => "tools/call", "params" => params}, frame) do
+    handle_tool(params["name"], params["arguments"] || %{}, frame)
+  end
+
+  def handle_request(_request, frame) do
+    {:error, Error.protocol(:method_not_found), frame}
+  end
+
+  @impl true
+  def handle_notification(_, frame), do: {:noreply, frame}
+
+  @impl true
+  def handle_sampling(result, request_id, frame) do
+    if pid = frame.assigns[:test_pid] do
+      send(pid, {:sampling_handled, request_id, result, frame.assigns[:counter]})
+    end
+
+    frame =
+      frame
+      |> assign(:last_sampling_result, result)
+      |> assign(:last_sampling_request_id, request_id)
+
+    {:noreply, frame}
+  end
+
+  defp handle_tool("wait_signal", %{"signal" => sig_str}, frame) do
+    sig = String.to_atom(sig_str)
+    if pid = frame.assigns[:test_pid], do: send(pid, {:tool_running, self(), sig})
+
+    receive do
+      {:proceed, ^sig} -> :ok
+    after
+      5_000 -> :ok
+    end
+
+    Response.tool()
+    |> Response.text("done #{sig_str}")
+    |> Response.to_protocol()
+    |> then(&{:reply, &1, frame})
+  end
+
+  defp handle_tool("increment", _args, frame) do
+    counter = (frame.assigns[:counter] || 0) + 1
+    frame = assign(frame, :counter, counter)
+
+    Response.tool()
+    |> Response.text("count=#{counter}")
+    |> Response.to_protocol()
+    |> then(&{:reply, &1, frame})
+  end
+
+  defp handle_tool("crash", _args, _frame) do
+    raise "intentional crash from AsyncDispatchTestServer"
+  end
+
+  defp handle_tool("echo", %{"value" => value}, frame) do
+    Response.tool()
+    |> Response.text(value)
+    |> Response.to_protocol()
+    |> then(&{:reply, &1, frame})
+  end
+
+  defp handle_tool(name, _args, frame) do
+    {:error, Error.protocol(:invalid_params, %{message: "unknown tool: #{name}"}), frame}
+  end
+end


### PR DESCRIPTION
## Problem

`Anubis.Server.Session` runs tool handlers (and every other `module.handle_request/2`) inline inside `handle_call`, blocking the GenServer mailbox until the handler returns. Consequences:

- `notifications/cancelled` cannot be processed while a slow tool runs — the spec's only abort mechanism is broken for long-running tools.
- Sampling/roots/elicitation responses, `notifications/initialized`, `tools/list_changed`, and user-defined `handle_info`/`handle_cast` are all delayed by an in-flight tool.

[duics raised this](https://github.com/zoedsoupe/anubis-mcp/issues/143#issuecomment-4343231072) on #143 after the routing fix in #144 landed: _"one long-running tool call would cause other parallel tool calls to time out since they run sequentially"_. duics later [confirmed Claude does not actually fire parallel tool calls per session](https://github.com/zoedsoupe/anubis-mcp/issues/143#issuecomment-4346210890), so true parallel execution is unmotivated for now — but the mailbox-blocking problem affects every Anubis user with a slow tool, regardless of client.

## Solution

Run every `module.handle_request/2` in a `Task.Supervisor.async_nolink` task on the per-server `task_supervisor` (already in the supervision tree at [lib/anubis/server/supervisor.ex#L176](lib/anubis/server/supervisor.ex#L176), previously unused). Session keeps single-in-flight semantics via a `:queue`. Frame mutations stay single-writer (the Session GenServer applies them in `handle_info`).

- `state.in_flight` tracks the running task (`ref`, `pid`, `request_id`, `from`, `started_at`, `method`).
- `state.request_queue` holds `{request, ctx, from}` tuples while a task is in flight; drained on completion in arrival order.
- `state.deferred_callbacks` holds `{:cast, msg}` / `{:info, msg}` for competing frame writers (sampling/roots/elicitation responses, non-cancellation client notifications, user `handle_cast`/`handle_info`); applied in arrival order after the in-flight task completes.
- `notifications/cancelled` is _not_ deferred — it processes inline, calling `Task.Supervisor.terminate_child` on the in-flight task pid (or removing from the queue) and replying `Request cancelled` so the Plug doesn't time out.
- `terminate/2` replies `internal_error` to in-flight + queued callers so Plug returns immediately on shutdown.
- `[:anubis_mcp, :server, :tool_call]` (defined but unemitted previously) now emits via `:telemetry.span/3` around the handler.

No public API change. `GenServer.call(session_pid, {:mcp_request, ...}, timeout)` from the Plug still receives `{:ok, encoded}` synchronously — just after the task completes instead of inline.

## Rationale

`async_nolink` over `async`: tool crashes don't kill the Session; `{:DOWN, ref, ...}` arrives as a normal message and the queue drains.

Single-in-flight queue over parallel exec: concurrent frame mutations would race, breaking the existing `Anubis.Server.Behaviour` contract. Per duics's empirical follow-up, no known client issues parallel `tools/call` per session today, so the multi-tool feature is deferred until a real consumer demands it.

Per-server local `Task.Supervisor`: always co-located with the Session, so distribution-safe — pluggable Registry (`Registry.Local`, Horde, etc.) and pluggable session store (Redis at [lib/anubis/server/session/store/redis.ex](lib/anubis/server/session/store/redis.ex)) are unaffected. `to_serializable/1` continues to exclude transient fields.

