### PR TITLE
feat: add Registry.PG for distributed session tracking via :pg

### DIFF
--- a/lib/anubis/server/registry/pg.ex
+++ b/lib/anubis/server/registry/pg.ex
@@ -64,7 +64,6 @@ defmodule Anubis.Server.Registry.PG do
   get their own isolated scope.
   """
   @impl Anubis.Server.Registry
-  @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
     name = Keyword.fetch!(opts, :name)
     scope = pg_scope(name)
@@ -85,7 +84,6 @@ defmodule Anubis.Server.Registry.PG do
   when it exits.
   """
   @impl Anubis.Server.Registry
-  @spec register_session(name :: term(), Anubis.Server.Registry.session_id(), pid()) :: :ok
   def register_session(name, session_id, pid) do
     :pg.join(pg_scope(name), session_id, pid)
     :ok
@@ -100,8 +98,6 @@ defmodule Anubis.Server.Registry.PG do
   routed there by the Erlang runtime.
   """
   @impl Anubis.Server.Registry
-  @spec lookup_session(name :: term(), Anubis.Server.Registry.session_id()) ::
-          {:ok, pid()} | {:error, :not_found}
   def lookup_session(name, session_id) do
     case :pg.get_members(pg_scope(name), session_id) do
       [pid | _rest] -> {:ok, pid}
@@ -119,7 +115,6 @@ defmodule Anubis.Server.Registry.PG do
   primarily for intentional teardown.
   """
   @impl Anubis.Server.Registry
-  @spec unregister_session(name :: term(), Anubis.Server.Registry.session_id()) :: :ok
   def unregister_session(name, session_id) do
     scope = pg_scope(name)
 

--- a/lib/anubis/server/registry/pg.ex
+++ b/lib/anubis/server/registry/pg.ex
@@ -85,8 +85,7 @@ defmodule Anubis.Server.Registry.PG do
   when it exits.
   """
   @impl Anubis.Server.Registry
-  @spec register_session(name :: term(), Anubis.Server.Registry.session_id(), pid()) ::
-          :ok | {:error, term()}
+  @spec register_session(name :: term(), Anubis.Server.Registry.session_id(), pid()) :: :ok
   def register_session(name, session_id, pid) do
     :pg.join(pg_scope(name), session_id, pid)
     :ok
@@ -109,7 +108,7 @@ defmodule Anubis.Server.Registry.PG do
       [] -> {:error, :not_found}
     end
   rescue
-    _error -> {:error, :not_found}
+    _e in [ArgumentError] -> {:error, :not_found}
   end
 
   @doc """
@@ -130,7 +129,7 @@ defmodule Anubis.Server.Registry.PG do
 
     :ok
   rescue
-    _error -> :ok
+    _e in [ArgumentError] -> :ok
   end
 
   # Derive a deterministic `:pg` scope atom from the registry name.

--- a/lib/anubis/server/registry/pg.ex
+++ b/lib/anubis/server/registry/pg.ex
@@ -1,0 +1,141 @@
+defmodule Anubis.Server.Registry.PG do
+  @moduledoc """
+  Distributed session registry backed by Erlang's `:pg` (process groups) module.
+
+  Uses a named `:pg` scope to track session PIDs across all nodes in an Erlang
+  cluster, enabling transparent cross-node request routing for horizontally
+  scaled MCP server deployments.
+
+  ## When to use this registry
+
+  The default `Anubis.Server.Registry.Local` stores session PIDs in a node-local
+  ETS table. In a multi-node deployment without sticky sessions this causes
+  failures:
+
+  1. An `initialize` request hits node A — session process starts there.
+  2. The `notifications/initialized` notification hits node B — no local session
+     found, 404 returned, notification lost.
+  3. A subsequent `tools/call` back to node A finds the live session with
+     `initialized: false` → `"Server not initialized"` error.
+
+  `Registry.PG` solves this by tracking session PIDs in a `:pg` scope that is
+  shared across all connected Erlang nodes. When node B receives any request for
+  a session that lives on node A:
+
+  1. `lookup_session/2` queries `:pg` and returns node A's session PID.
+  2. `GenServer.call/3` routes the request to node A transparently via
+     distributed Erlang — no serialisation, no HTTP hop.
+  3. The session on node A handles the request in its correct state.
+
+  `:pg` monitors registered processes and removes their entries automatically
+  when a process exits, so stale PIDs are never returned.
+
+  ## Requirements
+
+  - OTP 23+ (`:pg` was introduced in OTP 23 as a replacement for `:pg2`).
+  - All MCP server nodes must be connected via distributed Erlang. If you are
+    not already managing node clustering yourself, libraries such as
+    [libcluster](https://github.com/bitwalker/libcluster) can handle automatic
+    cluster formation for a variety of strategies including Kubernetes DNS,
+    Consul, and gossip protocols.
+
+  ## Usage
+
+      children = [
+        {MyServer, transport: {:streamable_http, start: true}, registry: {Anubis.Server.Registry.PG, []}}
+      ]
+
+  ## Pairing with a session store
+
+  `Registry.PG` routes requests to live session processes across the cluster.
+  It does **not** persist sessions across node restarts. To survive node crashes
+  or rolling deployments, pair this registry with an
+  `Anubis.Server.Session.Store` implementation (e.g. Redis or a database) so
+  that sessions can be restored on any node after a restart.
+  """
+
+  @behaviour Anubis.Server.Registry
+
+  @doc """
+  Returns a child spec that starts the `:pg` scope for this registry.
+
+  The scope is derived deterministically from `opts[:name]`, which Anubis
+  injects automatically. Multiple independent servers on the same node each
+  get their own isolated scope.
+  """
+  @impl Anubis.Server.Registry
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :name)
+    scope = pg_scope(name)
+
+    %{
+      id: {__MODULE__, scope},
+      start: {:pg, :start_link, [scope]},
+      type: :worker,
+      restart: :permanent
+    }
+  end
+
+  @doc """
+  Registers `pid` under `session_id` in the cluster-wide `:pg` scope.
+
+  Any node in the cluster can subsequently look up this PID via
+  `lookup_session/2`. `:pg` monitors the process and removes it automatically
+  when it exits.
+  """
+  @impl Anubis.Server.Registry
+  @spec register_session(name :: term(), Anubis.Server.Registry.session_id(), pid()) ::
+          :ok | {:error, term()}
+  def register_session(name, session_id, pid) do
+    :pg.join(pg_scope(name), session_id, pid)
+    :ok
+  end
+
+  @doc """
+  Looks up the PID for `session_id` across the entire cluster.
+
+  Returns `{:ok, pid}` if a live session process is registered on any node in
+  the cluster, or `{:error, :not_found}` otherwise. When the PID belongs to a
+  remote node, subsequent `GenServer.call/3` invocations are transparently
+  routed there by the Erlang runtime.
+  """
+  @impl Anubis.Server.Registry
+  @spec lookup_session(name :: term(), Anubis.Server.Registry.session_id()) ::
+          {:ok, pid()} | {:error, :not_found}
+  def lookup_session(name, session_id) do
+    case :pg.get_members(pg_scope(name), session_id) do
+      [pid | _rest] -> {:ok, pid}
+      [] -> {:error, :not_found}
+    end
+  rescue
+    _error -> {:error, :not_found}
+  end
+
+  @doc """
+  Removes `session_id` from the cluster-wide `:pg` scope.
+
+  Called by Anubis when a session is explicitly stopped. Note that `:pg` also
+  removes entries automatically when the session process exits, so this is
+  primarily for intentional teardown.
+  """
+  @impl Anubis.Server.Registry
+  @spec unregister_session(name :: term(), Anubis.Server.Registry.session_id()) :: :ok
+  def unregister_session(name, session_id) do
+    scope = pg_scope(name)
+
+    for pid <- :pg.get_members(scope, session_id) do
+      :pg.leave(scope, session_id, pid)
+    end
+
+    :ok
+  rescue
+    _error -> :ok
+  end
+
+  # Derive a deterministic `:pg` scope atom from the registry name.
+  # The registry name is a compile-time bounded atom, so there is no risk of
+  # atom table exhaustion.
+  # credo:disable-for-next-line Credo.Check.Warning.UnsafeToAtom
+  defp pg_scope(name), do: :"#{name}.pg"
+end

--- a/lib/anubis/server/registry/pg.ex
+++ b/lib/anubis/server/registry/pg.ex
@@ -56,13 +56,6 @@ defmodule Anubis.Server.Registry.PG do
 
   @behaviour Anubis.Server.Registry
 
-  @doc """
-  Returns a child spec that starts the `:pg` scope for this registry.
-
-  The scope is derived deterministically from `opts[:name]`, which Anubis
-  injects automatically. Multiple independent servers on the same node each
-  get their own isolated scope.
-  """
   @impl Anubis.Server.Registry
   def child_spec(opts) do
     name = Keyword.fetch!(opts, :name)
@@ -76,27 +69,12 @@ defmodule Anubis.Server.Registry.PG do
     }
   end
 
-  @doc """
-  Registers `pid` under `session_id` in the cluster-wide `:pg` scope.
-
-  Any node in the cluster can subsequently look up this PID via
-  `lookup_session/2`. `:pg` monitors the process and removes it automatically
-  when it exits.
-  """
   @impl Anubis.Server.Registry
   def register_session(name, session_id, pid) do
     :pg.join(pg_scope(name), session_id, pid)
     :ok
   end
 
-  @doc """
-  Looks up the PID for `session_id` across the entire cluster.
-
-  Returns `{:ok, pid}` if a live session process is registered on any node in
-  the cluster, or `{:error, :not_found}` otherwise. When the PID belongs to a
-  remote node, subsequent `GenServer.call/3` invocations are transparently
-  routed there by the Erlang runtime.
-  """
   @impl Anubis.Server.Registry
   def lookup_session(name, session_id) do
     case :pg.get_members(pg_scope(name), session_id) do
@@ -107,13 +85,6 @@ defmodule Anubis.Server.Registry.PG do
     _e in [ArgumentError] -> {:error, :not_found}
   end
 
-  @doc """
-  Removes `session_id` from the cluster-wide `:pg` scope.
-
-  Called by Anubis when a session is explicitly stopped. Note that `:pg` also
-  removes entries automatically when the session process exits, so this is
-  primarily for intentional teardown.
-  """
   @impl Anubis.Server.Registry
   def unregister_session(name, session_id) do
     scope = pg_scope(name)

--- a/lib/anubis/server/supervisor.ex
+++ b/lib/anubis/server/supervisor.ex
@@ -119,7 +119,14 @@ defmodule Anubis.Server.Supervisor do
       children =
         case transport do
           :stdio ->
-            build_stdio_children(server, layer, transport_opts, task_supervisor, session_config, task_store_child)
+            build_stdio_children(
+              server,
+              layer,
+              transport_opts,
+              task_supervisor,
+              session_config,
+              task_store_child
+            )
 
           _ ->
             build_http_children(
@@ -173,9 +180,11 @@ defmodule Anubis.Server.Supervisor do
 
   # Auto-select registry: STDIO -> None, HTTP -> Local
   defp resolve_registry(opts, transport, server) do
+    name = Registry.registry_name(server)
+
     case Keyword.get(opts, :registry) do
       {mod, registry_opts} ->
-        {mod, registry_opts}
+        {mod, Keyword.put_new(registry_opts, :name, name)}
 
       nil ->
         case transport do
@@ -183,7 +192,6 @@ defmodule Anubis.Server.Supervisor do
             {Registry.None, []}
 
           _ ->
-            name = Registry.registry_name(server)
             {Registry.Local, [name: name]}
         end
     end

--- a/test/anubis/server/registry/pg_test.exs
+++ b/test/anubis/server/registry/pg_test.exs
@@ -96,10 +96,21 @@ defmodule Anubis.Server.Registry.PGTest do
       assert {:ok, ^pid} = PG.lookup_session(name, session_id)
 
       Process.exit(pid, :kill)
-      # Allow :pg to process the DOWN message before asserting
-      Process.sleep(50)
 
-      assert {:error, :not_found} = PG.lookup_session(name, session_id)
+      assert eventually(fn -> PG.lookup_session(name, session_id) == {:error, :not_found} end)
     end
+  end
+
+  # Retries `fun` up to 5 times with a linear backoff (10ms, 20ms, 30ms, 40ms, 50ms).
+  # Returns true as soon as `fun` returns true, raises if all attempts fail.
+  defp eventually(fun) do
+    Enum.reduce_while(1..5, nil, fn attempt, _acc ->
+      if fun.() do
+        {:halt, true}
+      else
+        Process.sleep(attempt * 10)
+        {:cont, nil}
+      end
+    end) || raise "condition never became true after 5 attempts"
   end
 end

--- a/test/anubis/server/registry/pg_test.exs
+++ b/test/anubis/server/registry/pg_test.exs
@@ -1,0 +1,100 @@
+defmodule Anubis.Server.Registry.PGTest do
+  use ExUnit.Case, async: false
+
+  alias Anubis.Server.Registry.PG
+
+  # Each test gets a unique registry name so the derived :pg scope is unique.
+  # async: false because :pg scopes are node-global; unique names prevent
+  # collisions but we still avoid async to keep process-exit timing predictable.
+  setup ctx do
+    name = :"test_registry_pg_#{ctx.test}"
+    start_supervised!(PG.child_spec(name: name))
+    %{name: name}
+  end
+
+  describe "child_spec/1" do
+    test "returns a worker child spec that starts a :pg scope", %{name: name} do
+      spec = PG.child_spec(name: name)
+
+      assert spec.type == :worker
+      assert spec.restart == :permanent
+      assert {mod, _fun, _args} = spec.start
+      assert mod == :pg
+    end
+
+    test "scopes are isolated per registry name" do
+      name_a = :"test_registry_pg_isolation_a_#{System.unique_integer()}"
+      name_b = :"test_registry_pg_isolation_b_#{System.unique_integer()}"
+
+      start_supervised!({PG, name: name_a}, id: :pg_a)
+      start_supervised!({PG, name: name_b}, id: :pg_b)
+
+      session_id = "session-#{System.unique_integer()}"
+      :ok = PG.register_session(name_a, session_id, self())
+
+      assert {:ok, _pid} = PG.lookup_session(name_a, session_id)
+      assert {:error, :not_found} = PG.lookup_session(name_b, session_id)
+    end
+  end
+
+  describe "register_session/3 and lookup_session/2" do
+    test "registered pid is found by lookup", %{name: name} do
+      session_id = "session-#{System.unique_integer()}"
+
+      assert :ok = PG.register_session(name, session_id, self())
+      assert {:ok, pid} = PG.lookup_session(name, session_id)
+      assert pid == self()
+    end
+
+    test "unregistered session_id returns not_found", %{name: name} do
+      assert {:error, :not_found} = PG.lookup_session(name, "nonexistent-session")
+    end
+
+    test "multiple sessions are tracked independently", %{name: name} do
+      session_a = "session-a-#{System.unique_integer()}"
+      session_b = "session-b-#{System.unique_integer()}"
+
+      pid_a = spawn(fn -> Process.sleep(:infinity) end)
+      pid_b = spawn(fn -> Process.sleep(:infinity) end)
+
+      :ok = PG.register_session(name, session_a, pid_a)
+      :ok = PG.register_session(name, session_b, pid_b)
+
+      assert {:ok, ^pid_a} = PG.lookup_session(name, session_a)
+      assert {:ok, ^pid_b} = PG.lookup_session(name, session_b)
+    end
+  end
+
+  describe "unregister_session/2" do
+    test "unregistered session is no longer found", %{name: name} do
+      session_id = "session-#{System.unique_integer()}"
+
+      :ok = PG.register_session(name, session_id, self())
+      assert {:ok, _pid} = PG.lookup_session(name, session_id)
+
+      :ok = PG.unregister_session(name, session_id)
+      assert {:error, :not_found} = PG.lookup_session(name, session_id)
+    end
+
+    test "unregistering a non-existent session is a no-op", %{name: name} do
+      assert :ok = PG.unregister_session(name, "ghost-session")
+    end
+  end
+
+  describe "automatic cleanup" do
+    test "lookup returns not_found after session process exits", %{name: name} do
+      session_id = "session-#{System.unique_integer()}"
+
+      pid = spawn(fn -> Process.sleep(:infinity) end)
+      :ok = PG.register_session(name, session_id, pid)
+
+      assert {:ok, ^pid} = PG.lookup_session(name, session_id)
+
+      Process.exit(pid, :kill)
+      # Allow :pg to process the DOWN message before asserting
+      Process.sleep(50)
+
+      assert {:error, :not_found} = PG.lookup_session(name, session_id)
+    end
+  end
+end

--- a/test/anubis/server/registry/pg_test.exs
+++ b/test/anubis/server/registry/pg_test.exs
@@ -57,6 +57,11 @@ defmodule Anubis.Server.Registry.PGTest do
       pid_a = spawn(fn -> Process.sleep(:infinity) end)
       pid_b = spawn(fn -> Process.sleep(:infinity) end)
 
+      on_exit(fn ->
+        Process.exit(pid_a, :kill)
+        Process.exit(pid_b, :kill)
+      end)
+
       :ok = PG.register_session(name, session_a, pid_a)
       :ok = PG.register_session(name, session_b, pid_b)
 


### PR DESCRIPTION
## Problem

When running an Anubis MCP server with the HTTP/streamable transport on more than one replica behind a load balancer (e.g. Kubernetes), requests are distributed across pods without sticky sessions. This breaks the MCP initialization handshake:

1. `initialize` hits pod A — session process starts there with `initialized: false`.
2. `notifications/initialized` hits pod B — `find_session` finds nothing locally, returns 404, notification is silently lost.
3. A subsequent `tools/call` back on pod A finds a live session with `initialized: false` → `"Server not initialized"` error.

There is also a secondary bug: `resolve_registry/3` in `Anubis.Server.Supervisor` passes custom registry opts through as-is, without injecting the `name:` key. This makes it impossible for custom registry implementations to correctly implement `child_spec/1`, since they have no way to derive the registry name.

## Solution

**`Anubis.Server.Registry.PG`** — a new built-in registry adapter backed by Erlang's `:pg` (process groups) module (OTP 23+). It tracks session PIDs in a named scope that is shared across all connected Erlang nodes. When any node receives a request for a session that lives on a different node, `:pg` returns the remote PID and `GenServer.call/3` routes the message transparently via distributed Erlang.

**Fix in `resolve_registry/3`** — the supervisor now injects `name: Registry.registry_name(server)` into custom registry opts via `Keyword.put_new/3`, so custom registry implementations can implement `child_spec/1` correctly.

Usage:

```elixir
{MyServer,
 transport: {:streamable_http, start: true},
 registry: {Anubis.Server.Registry.PG, []}}
```

For full crash recovery across node restarts, pair this with an `Anubis.Server.Session.Store` implementation so sessions can be restored on any node after a restart.

## Rationale

`:pg` ships with OTP (no new dependencies), is designed exactly for cluster-wide process group tracking, and handles automatic cleanup when a process exits. The session process always lives on the node that handled `initialize` — all other nodes simply route to it via distributed Erlang. This keeps session state authoritative and consistent without any extra coordination.