### PR TITLE
fix: recover sessions across crashes and supervisor restarts

### DIFF
--- a/lib/anubis/server/registry/local.ex
+++ b/lib/anubis/server/registry/local.ex
@@ -83,13 +83,17 @@ defmodule Anubis.Server.Registry.Local do
   end
 
   @impl GenServer
-  def handle_info({:DOWN, ref, :process, _pid, _reason}, state) do
+  def handle_info({:DOWN, ref, :process, dead_pid, _reason}, state) do
     case Map.pop(state.monitors, ref) do
       {nil, monitors} ->
         {:noreply, %{state | monitors: monitors}}
 
       {session_id, monitors} ->
-        :ets.delete(state.table, session_id)
+        case :ets.lookup(state.table, session_id) do
+          [{^session_id, ^dead_pid}] -> :ets.delete(state.table, session_id)
+          _ -> :ok
+        end
+
         {:noreply, %{state | monitors: monitors}}
     end
   end

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -43,6 +43,7 @@ defmodule Anubis.Server.Session do
           supported_versions: list(String.t()),
           transport: %{layer: module(), name: GenServer.name()},
           registry: module(),
+          registry_name: GenServer.name() | nil,
           session_idle_timeout: pos_integer(),
           expiry_timer: reference() | nil,
           pending_requests: %{
@@ -64,6 +65,7 @@ defmodule Anubis.Server.Session do
     {:name, {:required, {:custom, &Anubis.genserver_name/1}}},
     {:transport, {:required, {:custom, &Anubis.server_transport/1}}},
     {:registry, {:atom, {:default, Anubis.Server.Registry}}},
+    {:registry_name, {{:custom, &Anubis.genserver_name/1}, {:default, nil}}},
     {:session_idle_timeout, {{:integer, {:gte, 1}}, {:default, @default_session_idle_timeout}}},
     {:timeout, {:integer, {:default, to_timeout(second: 30)}}},
     {:task_supervisor, {:required, {:custom, &Anubis.genserver_name/1}}}
@@ -80,6 +82,9 @@ defmodule Anubis.Server.Session do
     * `:transport` — transport configuration `[layer: module, name: name]` (required)
     * `:task_supervisor` — name of the `Task.Supervisor` for async work (required)
     * `:registry` — session registry module (default: `Anubis.Server.Registry`)
+    * `:registry_name` — name of the registry process; when set the Session
+      registers itself on init so DynamicSupervisor-driven restarts stay
+      reachable from the registry (default: `nil`)
     * `:session_idle_timeout` — idle timeout in ms before session expires (default: 30 min)
     * `:timeout` — request timeout in ms (default: 30s)
   """
@@ -115,6 +120,7 @@ defmodule Anubis.Server.Session do
       supported_versions: protocol_versions,
       transport: Map.new(opts.transport),
       registry: opts.registry,
+      registry_name: opts[:registry_name],
       session_idle_timeout: opts.session_idle_timeout,
       expiry_timer: nil,
       pending_requests: %{},
@@ -123,12 +129,18 @@ defmodule Anubis.Server.Session do
       task_supervisor: opts.task_supervisor
     }
 
-    state = schedule_session_expiry(state)
+    state =
+      state
+      |> maybe_restore_from_store()
+      |> schedule_session_expiry()
+
+    register_with_registry(state)
 
     Logging.server_event("session_starting", %{
       session_id: opts.session_id,
       module: module,
-      server_info: server_info
+      server_info: server_info,
+      restored: state.initialized
     })
 
     Telemetry.execute(
@@ -143,6 +155,26 @@ defmodule Anubis.Server.Session do
     )
 
     {:ok, state, :hibernate}
+  end
+
+  defp register_with_registry(%{registry: registry, registry_name: name, session_id: id})
+       when not is_nil(name) do
+    registry.register_session(name, id, self())
+  end
+
+  defp register_with_registry(_state), do: :ok
+
+  defp maybe_restore_from_store(%{session_id: id} = state) do
+    with store when not is_nil(store) <- Anubis.get_session_store_adapter(),
+         {:ok, persisted} when is_map(persisted) <- store.load(id, []) do
+      restored = from_serializable(persisted)
+
+      Logging.log(:debug, "Restoring session #{inspect(id)} from store", initialized: restored.initialized)
+
+      Map.merge(state, Map.delete(restored, :session_id))
+    else
+      _ -> state
+    end
   end
 
   # Request/Response handling

--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -343,7 +343,21 @@ if Code.ensure_loaded?(Plug) do
           start_new_session(opts, session_id)
 
         {:error, :not_found} ->
-          {:error, :no_session}
+          if session_in_store?(session_id) do
+            start_new_session(opts, session_id)
+          else
+            {:error, :no_session}
+          end
+      end
+    end
+
+    defp session_in_store?(session_id) do
+      case Anubis.get_session_store_adapter() do
+        nil ->
+          false
+
+        store ->
+          match?({:ok, _}, store.load(session_id, []))
       end
     end
 
@@ -358,12 +372,13 @@ if Code.ensure_loaded?(Plug) do
         transport: session_config.transport,
         session_idle_timeout: session_config.session_idle_timeout || 1_800_000,
         timeout: opts.timeout,
-        task_supervisor: session_config.task_supervisor
+        task_supervisor: session_config.task_supervisor,
+        registry: registry_mod,
+        registry_name: registry_name
       ]
 
       case ServerSupervisor.start_session(server, session_opts) do
         {:ok, pid} ->
-          registry_mod.register_session(registry_name, session_id, pid)
           {:ok, pid}
 
         {:error, {:already_started, pid}} ->

--- a/test/anubis/server/transport/streamable_http/session_recovery_test.exs
+++ b/test/anubis/server/transport/streamable_http/session_recovery_test.exs
@@ -1,0 +1,206 @@
+defmodule Anubis.Server.Transport.StreamableHTTP.SessionRecoveryTest do
+  @moduledoc """
+  Regression tests for "session drops" reported in dev mode (e.g. after a
+  recompile). The underlying issue is broader than recompilation: any time the
+  Session GenServer dies and is restarted by the DynamicSupervisor — or any
+  time the supervisor's `:one_for_all` strategy takes the whole subtree down —
+  subsequent client requests with the same `mcp-session-id` are rejected.
+
+  Two failure modes are exercised here:
+
+    1. With no session store configured: after a Session crash the
+       DynamicSupervisor restarts the child, but the new pid is never
+       re-registered in the ETS registry, so the Plug returns "No active
+       session" forever.
+
+    2. With a session store configured: the Session faithfully persists state
+       on init, but nothing in `Plug.find_or_create_session/3` consults the
+       store when the session is missing from the registry — `store.load/2` has
+       no callers in lib code today. Even fully-persisted sessions are
+       irrecoverable.
+  """
+  use Anubis.MCP.Case, async: false
+
+  import ExUnit.CaptureLog
+  import Plug.Conn
+  import Plug.Test
+
+  alias Anubis.MCP.Message
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Supervisor, as: ServerSupervisor
+  alias Anubis.Server.Transport.StreamableHTTP
+  alias Anubis.Server.Transport.StreamableHTTP.Plug, as: StreamableHTTPPlug
+  alias Anubis.Test.MockSessionStore
+
+  @session_id "session-recovery-test"
+
+  defp setup_session_config(opts) do
+    task_sup = Registry.task_supervisor_name(StubServer)
+    transport_name = Registry.transport_name(StubServer, StubTransport)
+
+    session_config = %{
+      server_module: StubServer,
+      registry_mod: Keyword.get(opts, :registry_mod, Registry.Local),
+      transport: [layer: StubTransport, name: transport_name],
+      session_idle_timeout: nil,
+      timeout: 30_000,
+      task_supervisor: task_sup
+    }
+
+    :persistent_term.put({ServerSupervisor, StubServer, :session_config}, session_config)
+    session_config
+  end
+
+  defp boot_streamable_http_stack do
+    task_sup = Registry.task_supervisor_name(StubServer)
+    start_supervised!({Task.Supervisor, name: task_sup})
+
+    transport_name = Registry.transport_name(StubServer, StubTransport)
+    start_supervised!({StubTransport, name: transport_name})
+
+    registry_name = Registry.registry_name(StubServer)
+    start_supervised!({Registry.Local, name: registry_name})
+
+    session_config = setup_session_config(registry_mod: Registry.Local)
+
+    on_exit(fn ->
+      :persistent_term.erase({ServerSupervisor, StubServer, :session_config})
+    end)
+
+    session_sup_name = Registry.session_supervisor_name(StubServer)
+    start_supervised!({DynamicSupervisor, name: session_sup_name, strategy: :one_for_one})
+
+    http_name = Registry.transport_name(StubServer, :streamable_http)
+
+    {:ok, _transport} =
+      start_supervised({StreamableHTTP, server: StubServer, name: http_name, task_supervisor: task_sup})
+
+    opts = StreamableHTTPPlug.init(server: StubServer)
+
+    %{
+      opts: opts,
+      task_sup: task_sup,
+      registry_name: registry_name,
+      session_sup_name: session_sup_name,
+      session_config: session_config
+    }
+  end
+
+  defp initialize_via_plug(opts, session_id) do
+    init_request =
+      build_request("initialize", %{
+        "protocolVersion" => "2025-03-26",
+        "clientInfo" => %{"name" => "test", "version" => "1.0.0"},
+        "capabilities" => %{}
+      })
+
+    {:ok, body} = Message.encode_request(init_request, "init_1")
+
+    conn =
+      :post
+      |> conn("/", body)
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("accept", "application/json")
+      |> put_req_header("mcp-session-id", session_id)
+      |> StreamableHTTPPlug.call(opts)
+
+    assert conn.status == 200, "initialize handshake should succeed, got #{conn.status} #{conn.resp_body}"
+
+    initialized = build_notification("notifications/initialized", %{})
+
+    {:ok, init_body} = Message.encode_notification(initialized)
+
+    :post
+    |> conn("/", init_body)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("mcp-session-id", session_id)
+    |> StreamableHTTPPlug.call(opts)
+
+    Process.sleep(20)
+    :ok
+  end
+
+  defp ping(opts, session_id) do
+    request = build_request("ping", %{})
+    {:ok, body} = Message.encode_request(request, "ping_1")
+
+    :post
+    |> conn("/", body)
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("accept", "application/json")
+    |> put_req_header("mcp-session-id", session_id)
+    |> StreamableHTTPPlug.call(opts)
+  end
+
+  describe "session recovery without session store" do
+    setup do
+      ctx = boot_streamable_http_stack()
+      capture_log(fn -> initialize_via_plug(ctx.opts, @session_id) end)
+      ctx
+    end
+
+    test "follow-up request survives a Session crash", ctx do
+      {:ok, session_pid} = Registry.Local.lookup_session(ctx.registry_name, @session_id)
+      assert Process.alive?(session_pid)
+
+      ref = Process.monitor(session_pid)
+
+      Process.exit(session_pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^session_pid, _}, 500
+      # let the DynamicSupervisor restart and the registry process the DOWN
+      Process.sleep(50)
+
+      conn = ping(ctx.opts, @session_id)
+
+      assert conn.status == 200,
+             "expected the transport to recover the session after a crash, " <>
+               "got status #{conn.status} with body #{conn.resp_body}"
+    end
+  end
+
+  describe "session recovery with persistence store" do
+    setup do
+      {:ok, _} = MockSessionStore.start_link([])
+      MockSessionStore.reset!()
+
+      original_config = Application.get_env(:anubis_mcp, :session_store)
+
+      Application.put_env(:anubis_mcp, :session_store,
+        enabled: true,
+        adapter: MockSessionStore,
+        ttl: 1_800_000
+      )
+
+      on_exit(fn ->
+        if original_config do
+          Application.put_env(:anubis_mcp, :session_store, original_config)
+        else
+          Application.delete_env(:anubis_mcp, :session_store)
+        end
+      end)
+
+      ctx = boot_streamable_http_stack()
+      capture_log(fn -> initialize_via_plug(ctx.opts, @session_id) end)
+      ctx
+    end
+
+    test "persisted session is rehydrated after the Session pid dies", ctx do
+      assert {:ok, stored} = MockSessionStore.load(@session_id, [])
+      assert stored.initialized == true, "initialize/initialized should have persisted state"
+
+      {:ok, session_pid} = Registry.Local.lookup_session(ctx.registry_name, @session_id)
+      ref = Process.monitor(session_pid)
+
+      Process.exit(session_pid, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^session_pid, _}, 500
+      Process.sleep(50)
+
+      conn = ping(ctx.opts, @session_id)
+
+      assert conn.status == 200,
+             "expected the transport to rehydrate the persisted session, " <>
+               "got status #{conn.status} with body #{conn.resp_body}"
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Sessions could become permanently unreachable from the client after a single Session GenServer crash or any supervisor-subtree restart — surfaced most visibly during Phoenix code-reloads in dev. The next request with the same `mcp-session-id` returned 400 "No active session" until the client started a brand-new `initialize`.

Two architectural gaps caused this:

1. **Restarted Sessions weren't re-registered.** The DynamicSupervisor faithfully restarted crashed Sessions (`restart: :permanent`), but registration was done by the Plug *after* `start_session/2`, so restart-spawned pids never reached the registry.
2. **The session store was write-only.** `Anubis.Server.Session.maybe_persist_session/1` saved state on `initialize`/`notifications/initialized`, but nothing in lib called `store.load/2` — `from_serializable/1` existed but had no callers. Even fully-persisted sessions couldn't recover.

## Changes

- **`lib/anubis/server/session.ex`** — Session now self-registers in `init/1` via a new optional `:registry_name` option, and rehydrates from the configured store via the existing `from_serializable/1`. Restarts triggered by the DynamicSupervisor now transparently rejoin the registry, and rehydration restores full state when persistence is configured.
- **`lib/anubis/server/transport/streamable_http/plug.ex`** — `start_new_session/2` passes `registry`/`registry_name` down to the Session and no longer registers from the Plug side. `find_or_create_session/3` falls through to `start_new_session/2` for non-`initialize` messages when the store has state, so a fully-restarted supervisor subtree can still serve existing session-ids.
- **`lib/anubis/server/registry/local.ex`** — The `:DOWN` handler verifies the ETS entry still points at the dead pid before deletion. Without this, a stale `:DOWN` from the old pid could race past the restarted Session's registration and wipe out the new entry.

## Test plan

- [x] Added `test/anubis/server/transport/streamable_http/session_recovery_test.exs` with two regression tests — one without a session store (proves registry re-registration), one with `MockSessionStore` configured (proves store rehydration). Both fail without these changes and pass with them.
- [x] Full suite: `33 doctests, 646 tests, 0 failures, 11 excluded, 1 skipped`.

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Session crashes mid-request | Permanent "No active session" | DynamicSupervisor restart re-registers; request reaches the new Session (returns "Server not initialized" without persistence — recoverable by re-`initialize`) |
| Session crashes, persistence configured | Same permanent failure | Restarted Session restores full state from store; request continues transparently |
| Whole supervisor subtree restarts, persistence configured | All sessions gone for clients | Plug starts a fresh Session for an existing session-id when the store has state; Session restores and continues |

## Follow-up worth flagging

`Anubis.Server.Supervisor` still uses `:one_for_all` (`lib/anubis/server/supervisor.ex:113`), so any sibling crash still cascades. With these changes the cascade is *survivable* when persistence is enabled, but `:rest_for_one` (or a finer split) would reduce blast radius further. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)