### PR TITLE
Echo request id in "Server not initialized" error

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -618,7 +618,7 @@ defmodule Anubis.Server.Session do
         handle_server_ping(decoded, state)
 
       not is_server_initialized(decoded, state) ->
-        handle_server_not_initialized(state)
+        handle_server_not_initialized(decoded, state)
 
       Message.is_request(decoded) ->
         handle_request(decoded, transport_context, from, state)
@@ -632,7 +632,7 @@ defmodule Anubis.Server.Session do
     {:reply, {:ok, encode_reply(Message.build_response(%{}, request_id))}, state}
   end
 
-  defp handle_server_not_initialized(state) do
+  defp handle_server_not_initialized(decoded, state) do
     error = Error.protocol(:invalid_request, %{message: "Server not initialized"})
 
     Logging.server_event(
@@ -641,7 +641,7 @@ defmodule Anubis.Server.Session do
       level: :warning
     )
 
-    {:reply, {:ok, encode_reply(Error.build_json_rpc(error))}, state}
+    {:reply, {:ok, encode_reply(Error.build_json_rpc(error, decoded["id"]))}, state}
   end
 
   defp handle_invalid_request(state) do

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -51,10 +51,15 @@ defmodule Anubis.Server.SessionTest do
           id: :uninit_session
         )
 
-      request = build_request("tools/list", 123)
+      request = build_request("tools/list", %{}, 123)
 
-      assert {:ok, _} =
+      assert {:ok, encoded} =
                GenServer.call(session, {:mcp_request, request, %{}})
+
+      assert {:ok, [decoded]} = Message.decode(encoded)
+      # error must echo the request id, else the client can't correlate the reply
+      assert decoded["id"] == 123
+      assert decoded["error"]["data"]["message"] == "Server not initialized"
     end
 
     test "accept ping requests when not initialized" do


### PR DESCRIPTION
## Problem

A request received before the session is initialized gets the `"Server not initialized"` error back with a **random** id: `handle_server_not_initialized/1` calls `Error.build_json_rpc(error)` without the request id, and `build_json_rpc/2` defaults `id` to `ID.generate_error_id/0`.

A spec-compliant JSON-RPC client correlates responses to requests by `id`, so it can never match this error to its pending request and **waits indefinitely** — the call hangs instead of failing fast. Easy to hit when a client reuses a session after a server restart, or sends a request before completing the `initialize` handshake. Every other error path in `session.ex` already threads the request id; this one was the lone exception.

## Fix

Thread `decoded["id"]` through `handle_server_not_initialized/2`.

## Test

Extends the existing "rejects requests when not initialized" test to assert the error echoes the originating request id (123). Red before this change (the id was a random err_*), green after.