### PR TITLE
fix: generate auth child_spec branch conditionally

### DIFF
--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -280,6 +280,40 @@ defmodule Anubis.Server do
 
   @doc false
   defmacro __using__(opts) do
+    authorization_config = Keyword.get(opts, :authorization)
+
+    child_spec =
+      if authorization_config do
+        quote generated: true do
+          def child_spec(opts) do
+            opts =
+              if Keyword.has_key?(opts, :authorization) do
+                opts
+              else
+                Keyword.put(opts, :authorization, @__authorization_config__)
+              end
+
+            %{
+              id: __MODULE__,
+              start: {Anubis.Server.Supervisor, :start_link, [__MODULE__, opts]},
+              type: :supervisor,
+              restart: :permanent
+            }
+          end
+        end
+      else
+        quote generated: true do
+          def child_spec(opts) do
+            %{
+              id: __MODULE__,
+              start: {Anubis.Server.Supervisor, :start_link, [__MODULE__, opts]},
+              type: :supervisor,
+              restart: :permanent
+            }
+          end
+        end
+      end
+
     quote generated: true do
       @behaviour Anubis.Server
 
@@ -296,27 +330,11 @@ defmodule Anubis.Server do
       @before_compile Anubis.Server
       @after_compile Anubis.Server
 
-      @__authorization_config__ unquote(Keyword.get(opts, :authorization))
+      @__authorization_config__ unquote(authorization_config)
 
       def __authorization__, do: @__authorization_config__
 
-      def child_spec(opts) do
-        auth_config = @__authorization_config__
-
-        opts =
-          if auth_config && not Keyword.has_key?(opts, :authorization) do
-            Keyword.put(opts, :authorization, auth_config)
-          else
-            opts
-          end
-
-        %{
-          id: __MODULE__,
-          start: {Anubis.Server.Supervisor, :start_link, [__MODULE__, opts]},
-          type: :supervisor,
-          restart: :permanent
-        }
-      end
+      unquote(child_spec)
 
       defoverridable child_spec: 1
     end

--- a/test/anubis/server/child_spec_test.exs
+++ b/test/anubis/server/child_spec_test.exs
@@ -1,0 +1,130 @@
+defmodule Anubis.Server.ChildSpecTest do
+  use ExUnit.Case, async: false
+
+  @auth_config [
+    authorization_servers: ["https://auth.example.com"],
+    resource: "https://api.example.com"
+  ]
+
+  defmodule NoAuthorizationServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "no-auth-child-spec-server",
+      version: "1.0.0",
+      capabilities: []
+  end
+
+  defmodule AuthorizationServer do
+    @moduledoc false
+
+    @auth_config [
+      authorization_servers: ["https://auth.example.com"],
+      resource: "https://api.example.com"
+    ]
+    use Anubis.Server,
+      name: "auth-child-spec-server",
+      version: "1.0.0",
+      capabilities: [],
+      authorization: @auth_config
+  end
+
+  test "compiling a server without authorization emits no warnings" do
+    module = Module.concat(__MODULE__, "NoAuthCompileProbe#{System.unique_integer([:positive])}")
+
+    {_compiled, diagnostics} =
+      Code.with_diagnostics(fn ->
+        Code.compile_string("""
+        defmodule #{inspect(module)} do
+          use Anubis.Server,
+            name: "issue-173-no-auth",
+            version: "1.0.0",
+            capabilities: []
+        end
+        """)
+      end)
+
+    assert diagnostics == []
+  end
+
+  test "generated child_spec/1 for a server without authorization has no authorization merge" do
+    module = Module.concat(__MODULE__, "NoAuthStructProbe#{System.unique_integer([:positive])}")
+
+    child_spec = compile_child_spec_abstract_code(module)
+
+    refute contains_keyword_put_call?(child_spec)
+  end
+
+  test "child_spec/1 omits authorization when the server has no authorization config" do
+    %{start: {Anubis.Server.Supervisor, :start_link, [NoAuthorizationServer, opts]}} =
+      NoAuthorizationServer.child_spec(transport: :stdio)
+
+    assert opts == [transport: :stdio]
+    refute Keyword.has_key?(opts, :authorization)
+  end
+
+  test "child_spec/1 merges the configured authorization when the caller omits it" do
+    %{start: {Anubis.Server.Supervisor, :start_link, [AuthorizationServer, opts]}} =
+      AuthorizationServer.child_spec(transport: :streamable_http)
+
+    assert opts[:transport] == :streamable_http
+    assert opts[:authorization] == @auth_config
+  end
+
+  test "child_spec/1 keeps caller-provided authorization" do
+    caller_auth = [
+      authorization_servers: ["https://override.example.com"],
+      resource: "https://override.example.com"
+    ]
+
+    %{start: {Anubis.Server.Supervisor, :start_link, [AuthorizationServer, opts]}} =
+      AuthorizationServer.child_spec(authorization: caller_auth)
+
+    assert opts[:authorization] == caller_auth
+  end
+
+  defp compile_child_spec_abstract_code(module) do
+    source = """
+    defmodule #{inspect(module)} do
+      use Anubis.Server,
+        name: "issue-173-no-auth",
+        version: "1.0.0",
+        capabilities: []
+    end
+    """
+
+    child_spec_abstract_code(source)
+  end
+
+  defp child_spec_abstract_code(source) do
+    compiler_options = Code.compiler_options()
+
+    forms =
+      try do
+        Code.compiler_options(debug_info: true)
+        [{_module, beam}] = Code.compile_string(source)
+        {:ok, {_module, [abstract_code: {:raw_abstract_v1, forms}]}} = :beam_lib.chunks(beam, [:abstract_code])
+        forms
+      after
+        Code.compiler_options(compiler_options)
+      end
+
+    Enum.find(forms, &match?({:function, _, :child_spec, 1, _}, &1))
+  end
+
+  defp contains_keyword_put_call?(term) do
+    term_contains?(term, fn
+      {:call, _, {:remote, _, {:atom, _, Keyword}, {:atom, _, :put}}, _} -> true
+      _ -> false
+    end)
+  end
+
+  defp term_contains?(term, predicate) do
+    cond do
+      predicate.(term) -> true
+      is_tuple(term) -> term |> Tuple.to_list() |> Enum.any?(&term_contains?(&1, predicate))
+      is_list(term) -> Enum.any?(term, &term_contains?(&1, predicate))
+      true -> false
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Fixes #173.

`use Anubis.Server` without an `:authorization` option previously generated an authorization merge path inside `child_spec/1` even though `@__authorization_config__` was known to be `nil` for that server.

Current `main` marks the generated code with `generated: true`, which masks the Elixir 1.20 diagnostic at the call site, but the no-authorization generated `child_spec/1` still structurally contains the unreachable authorization merge path.

## Solution

Generate different `child_spec/1` bodies at macro expansion time:

- when `:authorization` is configured, keep the existing behavior of adding it to child specs unless the caller already supplied `:authorization`
- when `:authorization` is not configured, emit a plain child spec with no authorization merge branch

Runtime behavior is unchanged:

- servers without configured authorization still pass caller opts through unchanged
- servers with configured authorization still add it to child specs when the caller omits `:authorization`
- caller-provided `:authorization` still takes precedence

## Rationale

This follows the direction suggested in #173: remove the dead branch from the generated no-authorization code rather than relying on generated-code warning suppression.

The regression coverage includes both:

- a diagnostics check for compiling a no-authorization server, and
- a structural generated-code assertion that the no-auth `child_spec/1` contains no `Keyword.put/3` authorization merge.

The structural assertion goes red against the pre-fix macro.

Tests run:

- `mix test test/anubis/server/child_spec_test.exs`
- `mix compile --force --warnings-as-errors`
- `mix test`
- `mix format --check-formatted`
- `mix credo --strict`
- `mix lint`

---

Disclosure: this PR was drafted with AI assistance and reviewed before submission.
