### PR TITLE
fix: prevent "Server not initialized" race on first request

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -671,7 +671,8 @@ defmodule Anubis.Server.Session do
       | protocol_version: protocol_version,
         protocol_module: protocol_module,
         client_info: client_info,
-        client_capabilities: client_capabilities
+        client_capabilities: client_capabilities,
+        initialized: true
     }
 
     maybe_persist_session(state)

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -62,6 +62,38 @@ defmodule Anubis.Server.SessionTest do
       assert decoded["error"]["data"]["message"] == "Server not initialized"
     end
 
+    test "accepts requests after initialize without notifications/initialized" do
+      transport_name = Registry.transport_name(StubServer, StubTransport)
+      task_sup = Registry.task_supervisor_name(StubServer)
+      session_name = Registry.session_name(StubServer, "init_no_notification")
+
+      session =
+        start_supervised!(
+          {Session,
+           session_id: "init_no_notification",
+           server_module: StubServer,
+           name: session_name,
+           transport: [layer: StubTransport, name: transport_name],
+           task_supervisor: task_sup},
+          id: :init_no_notification_session
+        )
+
+      init_msg =
+        init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, init_msg, %{}})
+
+      request = build_request("tools/list", %{}, 124)
+
+      assert {:ok, encoded} =
+               GenServer.call(session, {:mcp_request, request, %{}})
+
+      assert {:ok, [decoded]} = Message.decode(encoded)
+      assert decoded["id"] == 124
+      refute decoded["error"]
+      assert decoded["result"]["tools"]
+    end
+
     test "accept ping requests when not initialized" do
       transport_name = Registry.transport_name(StubServer, StubTransport)
       task_sup = Registry.task_supervisor_name(StubServer)


### PR DESCRIPTION
## Problem

On Streamable HTTP, the client sends `notifications/initialized` and its first request (e.g. `tools/list`) as two separate, near-simultaneous HTTP requests. The client sends them in order, but the transport doesn't guarantee order, so `tools/list` sometimes lands before the notification.

When it does, the session rejects it with `"Server not initialized"` ([gate](https://github.com/zoedsoupe/anubis-mcp/blob/main/lib/anubis/server/session.ex#L603-L605), [error](https://github.com/zoedsoupe/anubis-mcp/blob/main/lib/anubis/server/session.ex#L635-L645)). A client that doesn't retry then stalls. In my case, the Claude Desktop client hangs ~30s, then sends `notifications/cancelled`.

The spec lets a client send requests as soon as the server responds to `initialize`, so this is stricter than the spec requires.

## Solution

Mark the session initialized on the `initialize` response, not only in the `notifications/initialized` handler. Adds a test for a request arriving after `initialize` but before the notification.

## Rationale

Matches the official SDKs, which mark the session ready on the `initialize` response:

- TypeScript ([streamableHttp.ts#L501](https://github.com/modelcontextprotocol/typescript-sdk/blob/caa25503cdfc449d116c204e866bccc2617d7037/src/server/streamableHttp.ts#L501))
- Python ([#1478](https://github.com/modelcontextprotocol/python-sdk/pull/1478))
- Rust ([#788](https://github.com/modelcontextprotocol/rust-sdk/pull/788))

The spec says **SHOULD NOT**, not **MUST NOT**, so the notification isn't a hard gate.