### PR TITLE
fix(session): return encodable JSON-RPC errors when init/2 fails

### DIFF
--- a/lib/anubis/mcp/error.ex
+++ b/lib/anubis/mcp/error.ex
@@ -206,6 +206,20 @@ defmodule Anubis.MCP.Error do
   end
 
   @doc """
+  Wraps an arbitrary failure reason as an encodable MCP error.
+
+  Passes through existing `%Error{}` values (including those returned from
+  `init/2`). Other terms are converted to an internal error with a string
+  message safe for JSON encoding.
+  """
+  @spec wrap_reason(term()) :: t()
+  def wrap_reason(%__MODULE__{} = error), do: error
+
+  def wrap_reason(reason) do
+    protocol(:internal_error, %{message: stringify_reason(reason)})
+  end
+
+  @doc """
   Creates an error from a JSON-RPC error object.
 
   ## Examples
@@ -275,6 +289,14 @@ defmodule Anubis.MCP.Error do
   defp default_message(reason) do
     Map.get(@error_messages, reason, @error_messages.server_error)
   end
+
+  defp stringify_reason(reason) when is_binary(reason), do: reason
+
+  defp stringify_reason({tag, inner}) when is_atom(tag) do
+    "#{tag}: #{stringify_reason(inner)}"
+  end
+
+  defp stringify_reason(reason), do: inspect(reason, pretty: true, limit: 50)
 
   defp humanize(string) when is_binary(string) do
     string

--- a/lib/anubis/mcp/error.ex
+++ b/lib/anubis/mcp/error.ex
@@ -211,6 +211,18 @@ defmodule Anubis.MCP.Error do
   Passes through existing `%Error{}` values (including those returned from
   `init/2`). Other terms are converted to an internal error with a string
   message safe for JSON encoding.
+
+  ## Examples
+
+      iex> error = Anubis.MCP.Error.protocol(:invalid_params, %{message: "bad input"})
+      iex> Anubis.MCP.Error.wrap_reason(error)
+      %Anubis.MCP.Error{code: -32602, reason: :invalid_params, message: "Invalid params", data: %{message: "bad input"}}
+
+      iex> wrapped = Anubis.MCP.Error.wrap_reason({:init_failed, %{code: "unauthorized"}})
+      iex> wrapped.reason
+      :internal_error
+      iex> wrapped.data.message
+      "init_failed: %{code: \\"unauthorized\\"}"
   """
   @spec wrap_reason(term()) :: t()
   def wrap_reason(%__MODULE__{} = error), do: error

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -127,8 +127,13 @@ defmodule Anubis.Server do
   It receives the client's information and
   the current frame, allowing you to perform client-specific setup, validate capabilities,
   or prepare resources based on the connected client.
+
+  Returning `{:error, reason}` rejects the session: the transport answers the
+  request with an encodable JSON-RPC error. Return an `Anubis.MCP.Error` struct
+  to control the error code sent to the client; any other term is wrapped as an
+  internal error with a stringified message.
   """
-  @callback init(client_info :: map(), Frame.t()) :: {:ok, Frame.t()}
+  @callback init(client_info :: map(), Frame.t()) :: {:ok, Frame.t()} | {:error, term()}
 
   @doc """
   Handles a tool call request.

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -258,7 +258,7 @@ defmodule Anubis.Server.Session do
             reason: inspect(reason)
           })
 
-          {:reply, {:error, {:recovery_rejected, reason}}, state}
+          {:reply, {:error, Error.wrap_reason(reason)}, state}
 
         :default ->
           fallback_to_init(module, auto_state, frame, protocol_version, state)
@@ -1584,7 +1584,7 @@ defmodule Anubis.Server.Session do
   defp fallback_to_init(module, auto_state, frame, protocol_version, state) do
     case maybe_call_init(module, auto_state.client_info, frame) do
       {:ok, frame} -> do_complete_auto_init(auto_state, frame, protocol_version)
-      {:error, reason} -> {:reply, {:error, {:init_failed, reason}}, state}
+      {:error, reason} -> {:reply, {:error, Error.wrap_reason(reason)}, state}
     end
   end
 

--- a/lib/anubis/server/transport/streamable_http/plug.ex
+++ b/lib/anubis/server/transport/streamable_http/plug.ex
@@ -259,7 +259,7 @@ if Code.ensure_loaded?(Plug) do
         {:error, reason} ->
           send_jsonrpc_error(
             conn,
-            Error.protocol(:internal_error, %{reason: reason}),
+            Error.wrap_reason(reason),
             extract_request_id(message)
           )
       end
@@ -554,7 +554,7 @@ if Code.ensure_loaded?(Plug) do
 
       send_jsonrpc_error(
         conn,
-        Error.protocol(:internal_error, %{reason: reason}),
+        Error.wrap_reason(reason),
         extract_request_id(body)
       )
     end

--- a/test/anubis/mcp/error_test.exs
+++ b/test/anubis/mcp/error_test.exs
@@ -49,6 +49,21 @@ defmodule Anubis.MCP.ErrorTest do
     end
   end
 
+  describe "wrap_reason/1" do
+    test "passes through existing MCP errors" do
+      error = Error.protocol(:invalid_request, %{message: "unauthorized"})
+      assert Error.wrap_reason(error) == error
+    end
+
+    test "wraps tuples and other terms as encodable internal errors" do
+      error = Error.wrap_reason({:init_failed, %{code: "unauthorized"}})
+
+      assert error.reason == :internal_error
+      assert is_binary(error.data.message)
+      assert String.contains?(error.data.message, "init_failed")
+    end
+  end
+
   describe "transport errors" do
     test "transport/2 creates connection error" do
       error = Error.transport(:connection_refused)

--- a/test/anubis/server/session_expiry_test.exs
+++ b/test/anubis/server/session_expiry_test.exs
@@ -1,6 +1,7 @@
 defmodule Anubis.Server.SessionExpiryTest do
   use Anubis.MCP.Case, async: false
 
+  alias Anubis.MCP.Error
   alias Anubis.Server.Registry
   alias Anubis.Server.Session
   alias Anubis.Test.MockSessionStore
@@ -119,7 +120,7 @@ defmodule Anubis.Server.SessionExpiryTest do
       session_id = "expiry-reject-#{System.unique_integer([:positive])}"
       session = start_session(StubSessionRecoveryRejectServer, session_id)
 
-      assert {:error, {:recovery_rejected, :no_recovery_allowed}} =
+      assert {:error, %Error{reason: :internal_error, data: %{message: _}}} =
                Session.auto_initialize(session)
 
       state = :sys.get_state(session)
@@ -230,6 +231,22 @@ defmodule Anubis.Server.SessionExpiryTest do
 
       state = :sys.get_state(session)
       assert state.frame.assigns["key"] == "value"
+    end
+  end
+
+  describe "init/2 callback" do
+    test "callback returning {:error, reason} causes auto_initialize to fail with encodable error" do
+      session_id = "init-reject-#{System.unique_integer([:positive])}"
+      session = start_session(StubInitRejectServer, session_id)
+
+      assert {:error, %Error{reason: :internal_error, data: %{message: message}}} =
+               Session.auto_initialize(session)
+
+      assert is_binary(message)
+      refute String.contains?(message, "init_failed")
+
+      state = :sys.get_state(session)
+      refute state.initialized
     end
   end
 end

--- a/test/anubis/server/transport/streamable_http/plug_test.exs
+++ b/test/anubis/server/transport/streamable_http/plug_test.exs
@@ -587,4 +587,107 @@ defmodule Anubis.Server.Transport.StreamableHTTP.PlugTest do
       assert response["result"]["protocolVersion"]
     end
   end
+
+  describe "init/2 failure handling" do
+    defp setup_init_reject_server(server_module) do
+      task_sup = Registry.task_supervisor_name(server_module)
+      start_supervised!({Task.Supervisor, name: task_sup}, id: {server_module, :task_sup})
+
+      transport_name = Registry.transport_name(server_module, StubTransport)
+      start_supervised!({StubTransport, name: transport_name}, id: {server_module, :transport})
+
+      registry_name = Registry.registry_name(server_module)
+      start_supervised!({Registry.Local, name: registry_name}, id: {server_module, :registry})
+
+      naming_registry = Registry.naming_registry_name(registry_name)
+
+      start_supervised!({Elixir.Registry, keys: :unique, name: naming_registry},
+        id: {server_module, :naming_registry}
+      )
+
+      session_config = %{
+        server_module: server_module,
+        registry_mod: Registry.Local,
+        transport: [layer: StubTransport, name: transport_name],
+        session_idle_timeout: nil,
+        timeout: 30_000,
+        task_supervisor: task_sup
+      }
+
+      :persistent_term.put({ServerSupervisor, server_module, :session_config}, session_config)
+
+      on_exit(fn ->
+        :persistent_term.erase({ServerSupervisor, server_module, :session_config})
+      end)
+
+      session_sup_name = Registry.session_supervisor_name(server_module)
+
+      start_supervised!({DynamicSupervisor, name: session_sup_name, strategy: :one_for_one},
+        id: {server_module, :session_sup}
+      )
+
+      name = Registry.transport_name(server_module, :streamable_http)
+
+      start_supervised(
+        {StreamableHTTP, server: server_module, name: name, task_supervisor: task_sup},
+        id: {server_module, :transport_layer}
+      )
+
+      StreamableHTTPPlug.init(server: server_module)
+    end
+
+    test "returns JSON-RPC error when init/2 rejects with a plain reason" do
+      opts = setup_init_reject_server(StubInitRejectServer)
+
+      request = %{
+        "jsonrpc" => "2.0",
+        "id" => "req-init-fail",
+        "method" => "tools/list",
+        "params" => %{}
+      }
+
+      body = JSON.encode!(request)
+
+      conn =
+        :post
+        |> conn("/", body)
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("accept", "application/json")
+        |> StreamableHTTPPlug.call(opts)
+
+      assert conn.status == 400
+      assert {:ok, decoded} = Jason.decode(conn.resp_body)
+      assert decoded["jsonrpc"] == "2.0"
+      assert decoded["id"] == "req-init-fail"
+      assert decoded["error"]["code"] == -32_603
+      assert is_binary(decoded["error"]["message"])
+      assert is_binary(get_in(decoded, ["error", "data", "message"]))
+    end
+
+    test "passes through structured MCP errors returned from init/2" do
+      opts = setup_init_reject_server(StubInitRejectWithErrorServer)
+
+      request = %{
+        "jsonrpc" => "2.0",
+        "id" => "req-init-error",
+        "method" => "tools/list",
+        "params" => %{}
+      }
+
+      body = JSON.encode!(request)
+
+      conn =
+        :post
+        |> conn("/", body)
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("accept", "application/json")
+        |> StreamableHTTPPlug.call(opts)
+
+      assert conn.status == 400
+      assert {:ok, decoded} = Jason.decode(conn.resp_body)
+      assert decoded["error"]["code"] == -32_600
+      assert decoded["error"]["message"] == "Invalid Request"
+      assert get_in(decoded, ["error", "data", "message"]) == "unauthorized"
+    end
+  end
 end

--- a/test/support/stub_session_recovery_server.ex
+++ b/test/support/stub_session_recovery_server.ex
@@ -52,3 +52,49 @@ defmodule StubSessionRecoveryRejectServer do
     {:error, :no_recovery_allowed}
   end
 end
+
+defmodule StubInitRejectServer do
+  @moduledoc """
+  Test server that rejects session setup via init/2.
+  """
+
+  use Anubis.Server,
+    name: "Init Reject Test Server",
+    version: "1.0.0",
+    capabilities: []
+
+  alias Anubis.MCP.Error
+
+  @impl true
+  def handle_request(%{"method" => _}, frame) do
+    {:error, Error.protocol(:method_not_found), frame}
+  end
+
+  @impl true
+  def init(_client_info, _frame) do
+    {:error, %{code: "unauthorized"}}
+  end
+end
+
+defmodule StubInitRejectWithErrorServer do
+  @moduledoc """
+  Test server that rejects session setup via init/2 with a structured MCP error.
+  """
+
+  use Anubis.Server,
+    name: "Init Reject With Error Test Server",
+    version: "1.0.0",
+    capabilities: []
+
+  alias Anubis.MCP.Error
+
+  @impl true
+  def handle_request(%{"method" => _}, frame) do
+    {:error, Error.protocol(:method_not_found), frame}
+  end
+
+  @impl true
+  def init(_client_info, _frame) do
+    {:error, Error.protocol(:invalid_request, %{message: "unauthorized"})}
+  end
+end


### PR DESCRIPTION
## Summary

When `Server.init/2` (or session recovery) rejects a session, normalize the failure to an encodable `%Anubis.MCP.Error{}` instead of returning raw `{:init_failed, reason}` / `{:recovery_rejected, reason}` tuples that crash `JSON.encode!/1` in the StreamableHTTP transport.

## Motivation

Fixes the HTTP 500 + `Protocol.UndefinedError` reported in #205 when a server legitimately rejects a session in `init/2`. Clients now receive a well-formed JSON-RPC error they can act on.

## Changes

- Add `Error.wrap_reason/1` to pass through `%Error{}` and stringify other failure terms for JSON encoding
- Normalize `init/2` and `handle_session_expired/2` rejection paths in `Session`
- Use `Error.wrap_reason/1` in StreamableHTTP transport error handling (defense in depth)
- Add regression tests for plain and structured `init/2` rejections via HTTP and session auto-init

## Tests

```bash
mix test test/anubis/mcp/error_test.exs test/anubis/server/session_expiry_test.exs test/anubis/server/transport/streamable_http/plug_test.exs
```

All 57 tests pass.

## Notes

- SSE transport still has similar catch-alls; could be aligned in a follow-up.
- `notifications/initialized` path still assumes `init/2` returns `{:ok, frame}` — separate from the auto-init path covered here.

Fixes #205