### PR TITLE
fix(streamable_http): route session messages to owning SSE handler

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -409,7 +409,7 @@ defmodule Anubis.Server.Session do
   @impl GenServer
   def handle_info({:send_notification, method, params}, state) do
     with {:ok, notification} <- encode_notification(method, params),
-         :ok <- send_to_transport(state.transport, notification, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, notification, transport_opts(state)) do
       {:noreply, state}
     else
       {:error, err} ->
@@ -1156,6 +1156,10 @@ defmodule Anubis.Server.Session do
     Message.encode_notification(notification)
   end
 
+  defp transport_opts(state) do
+    [timeout: state.timeout, session_id: state.session_id]
+  end
+
   defp send_to_transport(nil, _data, _opts) do
     {:error, Error.transport(:no_transport, %{message: "No transport configured"})}
   end
@@ -1183,7 +1187,7 @@ defmodule Anubis.Server.Session do
     with :ok <- validate_client_capability(state, "sampling"),
          {:ok, request_data} <-
            encode_request("sampling/createMessage", params, request_id),
-         :ok <- send_to_transport(state.transport, request_data, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, request_data, transport_opts(state)) do
       Logging.server_event("sent_sampling_request", %{request_id: request_id})
       {:noreply, state}
     else
@@ -1314,7 +1318,7 @@ defmodule Anubis.Server.Session do
 
     with :ok <- validate_client_capability(state, "roots"),
          {:ok, request_data} <- encode_request("roots/list", %{}, request_id),
-         :ok <- send_to_transport(state.transport, request_data, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, request_data, transport_opts(state)) do
       Logging.server_event("sent_roots_request", %{request_id: request_id})
       {:noreply, state}
     else
@@ -1350,7 +1354,7 @@ defmodule Anubis.Server.Session do
              "requestId" => request_id,
              "reason" => "timeout"
            }),
-         :ok <- send_to_transport(state.transport, notification, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, notification, transport_opts(state)) do
       Logging.server_event(
         "roots_request_timeout_cancelled",
         %{request_id: request_id}
@@ -1397,7 +1401,7 @@ defmodule Anubis.Server.Session do
     with :ok <- validate_client_capability(state, "elicitation"),
          {:ok, request_data} <-
            encode_request("elicitation/create", params, request_id),
-         :ok <- send_to_transport(state.transport, request_data, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, request_data, transport_opts(state)) do
       Logging.server_event("sent_elicitation_request", %{request_id: request_id})
       {:noreply, state}
     else
@@ -1433,7 +1437,7 @@ defmodule Anubis.Server.Session do
              "requestId" => request_id,
              "reason" => "timeout"
            }),
-         :ok <- send_to_transport(state.transport, notification, timeout: state.timeout) do
+         :ok <- send_to_transport(state.transport, notification, transport_opts(state)) do
       Logging.server_event(
         "elicitation_request_timeout_cancelled",
         %{request_id: request_id}
@@ -2158,7 +2162,7 @@ defmodule Anubis.Server.Session do
         params = McpTask.to_protocol(task)
 
         with {:ok, notification} <- encode_notification("notifications/tasks/status", params) do
-          send_to_transport(state.transport, notification, timeout: state.timeout)
+          send_to_transport(state.transport, notification, transport_opts(state))
         end
 
       _ ->

--- a/lib/anubis/server/transport/streamable_http.ex
+++ b/lib/anubis/server/transport/streamable_http.ex
@@ -80,7 +80,15 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
 
   @impl Transport
   def send_message(transport, message, opts) when is_binary(message) do
-    GenServer.call(transport, {:send_message, message}, opts[:timeout])
+    timeout = opts[:timeout]
+
+    case Keyword.get(opts, :session_id) do
+      nil ->
+        GenServer.call(transport, {:send_message, message}, timeout)
+
+      session_id when is_binary(session_id) ->
+        GenServer.call(transport, {:route_to_session, session_id, message}, timeout)
+    end
   end
 
   @impl Transport

--- a/lib/anubis/server/transport/streamable_http.ex
+++ b/lib/anubis/server/transport/streamable_http.ex
@@ -80,7 +80,7 @@ defmodule Anubis.Server.Transport.StreamableHTTP do
 
   @impl Transport
   def send_message(transport, message, opts) when is_binary(message) do
-    timeout = opts[:timeout]
+    timeout = Keyword.get(opts, :timeout, 5000)
 
     case Keyword.get(opts, :session_id) do
       nil ->

--- a/lib/anubis/transport/behaviour.ex
+++ b/lib/anubis/transport/behaviour.ex
@@ -12,7 +12,7 @@ defmodule Anubis.Transport.Behaviour do
 
   @callback start_link(keyword()) :: GenServer.on_start()
   @callback send_message(t(), message(), list(opt)) :: :ok | {:error, reason()}
-            when opt: {:timeout, pos_integer()}
+            when opt: {:timeout, pos_integer()} | {:session_id, String.t()}
   @callback shutdown(t()) :: :ok | {:error, reason()}
 
   @doc """

--- a/test/anubis/server/transport/streamable_http_test.exs
+++ b/test/anubis/server/transport/streamable_http_test.exs
@@ -146,6 +146,49 @@ defmodule Anubis.Server.Transport.StreamableHTTPTest do
       end)
     end
 
+    test "send_message with session_id routes to that session only", %{transport: transport} do
+      session_a = "session-a-#{System.unique_integer([:positive])}"
+      session_b = "session-b-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      pid_a =
+        spawn(fn ->
+          :ok = StreamableHTTP.register_sse_handler(transport, session_a)
+          send(test_pid, {:handler_ready, :a})
+
+          receive do
+            {:sse_message, msg} -> send(test_pid, {:got, :a, msg})
+          end
+        end)
+
+      pid_b =
+        spawn(fn ->
+          :ok = StreamableHTTP.register_sse_handler(transport, session_b)
+          send(test_pid, {:handler_ready, :b})
+
+          receive do
+            {:sse_message, msg} -> send(test_pid, {:got, :b, msg})
+          end
+        end)
+
+      assert_receive {:handler_ready, :a}
+      assert_receive {:handler_ready, :b}
+
+      message = "session-scoped message"
+
+      assert :ok =
+               StreamableHTTP.send_message(transport, message,
+                 timeout: 5000,
+                 session_id: session_a
+               )
+
+      assert_receive {:got, :a, ^message}
+      refute_receive {:got, :b, _}, 200
+
+      StreamableHTTP.unregister_sse_handler(transport, session_a, pid_a)
+      StreamableHTTP.unregister_sse_handler(transport, session_b, pid_b)
+    end
+
     test "cleans up handlers when they crash", %{transport: transport} do
       session_id = "test-session-crash"
       test_pid = self()


### PR DESCRIPTION
## Summary

Thread `session_id` through `Session.send_to_transport/3` so `StreamableHTTP.send_message/3` routes server-originated messages to the emitting session's SSE handler instead of broadcasting to every connected handler.

Fixes #228

## Motivation

Session-originated notifications, sampling/elicitation/roots requests, and task status updates were delivered via `broadcast/2`, causing cross-session message leakage on StreamableHTTP when multiple sessions had active SSE connections.

## Changes

- Add `transport_opts/1` in `Session` to include `session_id` alongside `timeout` on all outbound transport sends
- Update `StreamableHTTP.send_message/3` to call `route_to_session` when `:session_id` is present; preserve broadcast behavior when absent
- Document `:session_id` in `Transport.Behaviour` opt typespec
- Add regression test verifying session-scoped delivery does not reach other sessions' handlers

## Tests

```bash
mix test test/anubis/server/transport/streamable_http_test.exs
```

Result: **11 tests, 0 failures**

## Notes

- STDIO and legacy SSE transports ignore the new opt (single-session semantics unchanged)
- Host-facing `send_message/3` without `:session_id` still broadcasts to all handlers
- When no handler/stream exists for the target session, routing returns `{:error, :no_sse_handler}` instead of silently delivering to the wrong session