### PR TITLE
fix: Stream the client SSE GET instead of buffering it (server push never delivered)

### DIFF
--- a/lib/anubis/transport/streamable_http.ex
+++ b/lib/anubis/transport/streamable_http.ex
@@ -509,13 +509,14 @@ defmodule Anubis.Transport.StreamableHTTP do
   end
 
   defp run_sse_task(parent, state) do
+    opts =
+      state.http_options
+      |> Keyword.put(:dest, self())
+      |> Keyword.put(:finch_name, state.finch_name)
+
     state.mcp_url
     |> URI.to_string()
-    |> SSE.connect(build_sse_headers(state),
-      dest: self(),
-      finch_name: state.finch_name,
-      transport_opts: state.transport_opts
-    )
+    |> SSE.connect(build_sse_headers(state), opts)
     |> Enum.each(&send(parent, {:sse_event, &1}))
 
     send(parent, {:sse_closed, :normal})

--- a/lib/anubis/transport/streamable_http.ex
+++ b/lib/anubis/transport/streamable_http.ex
@@ -509,11 +509,15 @@ defmodule Anubis.Transport.StreamableHTTP do
   end
 
   defp run_sse_task(parent, state) do
-    headers = build_sse_headers(state)
-    options = state.http_options
-    request = HTTP.build(:get, URI.to_string(state.mcp_url), headers, nil)
+    state.mcp_url
+    |> URI.to_string()
+    |> SSE.connect(build_sse_headers(state),
+      dest: self(),
+      finch_name: state.finch_name,
+      transport_opts: state.transport_opts
+    )
+    |> Enum.each(&send(parent, {:sse_event, &1}))
 
-    process_sse_request(request, state.finch_name, options, parent)
     send(parent, {:sse_closed, :normal})
   end
 
@@ -522,30 +526,6 @@ defmodule Anubis.Transport.StreamableHTTP do
     |> Map.put("accept", "text/event-stream")
     |> put_session_header(state.session_id)
     |> put_last_event_id_header(state.last_event_id)
-  end
-
-  defp process_sse_request(request, finch_name, options, parent) do
-    case HTTP.follow_redirect(request, finch_name, options) do
-      {:ok, %{status: 200, headers: resp_headers, body: body}} ->
-        handle_sse_response(resp_headers, body, parent)
-
-      {:ok, %{status: 405}} ->
-        Logging.transport_event(
-          "sse_not_supported",
-          "Server returned 405 for GET request"
-        )
-
-      error ->
-        Logging.transport_event("sse_connection_failed", %{error: error}, level: :warning)
-    end
-  end
-
-  defp handle_sse_response(headers, body, parent) do
-    if get_content_type(headers) == "text/event-stream" do
-      body
-      |> SSE.Parser.run()
-      |> Enum.each(fn event -> send(parent, {:sse_event, event}) end)
-    end
   end
 
   defp delete_session(state) do

--- a/test/anubis/transport/streamable_http_test.exs
+++ b/test/anubis/transport/streamable_http_test.exs
@@ -14,9 +14,6 @@ defmodule Anubis.Transport.StreamableHTTPTest do
     {:ok, bypass: bypass}
   end
 
-  # Waits for a StubClient response carrying a server-pushed notification,
-  # ignoring unrelated responses (e.g. the POST reply) that also reach the
-  # subscriber. Returns false if none arrives within `timeout`.
   defp await_pushed_notification(timeout) do
     deadline = System.monotonic_time(:millisecond) + timeout
     do_await_pushed_notification(deadline)
@@ -322,7 +319,6 @@ defmodule Anubis.Transport.StreamableHTTPTest do
       {:ok, stub_client} = StubClient.start_link()
       session_id = "test-session-sse-push"
 
-      # POST establishes the session, which starts the SSE GET.
       Bypass.stub(bypass, "POST", "/mcp", fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
@@ -332,10 +328,6 @@ defmodule Anubis.Transport.StreamableHTTPTest do
 
       Bypass.stub(bypass, "DELETE", "/mcp", fn conn -> Plug.Conn.resp(conn, 200, "") end)
 
-      # A held-open SSE GET that pushes a server-initiated notification and then
-      # keeps the connection open. The event must reach the client while the
-      # stream is still open — a buffering read only yields it once the stream
-      # closes, which for a real SSE stream never happens.
       Bypass.stub(bypass, "GET", "/mcp", fn conn ->
         conn = Plug.Conn.put_resp_header(conn, "content-type", "text/event-stream")
         conn = Plug.Conn.send_chunked(conn, 200)
@@ -364,9 +356,7 @@ defmodule Anubis.Transport.StreamableHTTPTest do
       {:ok, ping} = Message.encode_request(%{"method" => "ping", "params" => %{}}, "1")
       assert :ok = StreamableHTTP.send_message(transport, ping, timeout: 5000)
 
-      # Must arrive well inside the server's hold, proving the event is streamed
-      # rather than delivered when the connection closes. The POST response also
-      # reaches the subscriber, so wait specifically for the pushed notification.
+      # Well inside the server's 2s hold: a buffering read could only deliver on close.
       assert await_pushed_notification(500), "server-pushed notification was never forwarded"
 
       StreamableHTTP.shutdown(transport)

--- a/test/anubis/transport/streamable_http_test.exs
+++ b/test/anubis/transport/streamable_http_test.exs
@@ -14,6 +14,33 @@ defmodule Anubis.Transport.StreamableHTTPTest do
     {:ok, bypass: bypass}
   end
 
+  # Waits for a StubClient response carrying a server-pushed notification,
+  # ignoring unrelated responses (e.g. the POST reply) that also reach the
+  # subscriber. Returns false if none arrives within `timeout`.
+  defp await_pushed_notification(timeout) do
+    deadline = System.monotonic_time(:millisecond) + timeout
+    do_await_pushed_notification(deadline)
+  end
+
+  defp do_await_pushed_notification(deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if remaining > 0 do
+      receive do
+        {:stub_client_response, data} ->
+          if is_binary(data) and String.contains?(data, "notifications/message") do
+            true
+          else
+            do_await_pushed_notification(deadline)
+          end
+      after
+        remaining -> false
+      end
+    else
+      false
+    end
+  end
+
   describe "start_link/1" do
     test "successfully starts with valid options", %{bypass: bypass} do
       server_url = "http://localhost:#{bypass.port}"
@@ -285,6 +312,62 @@ defmodule Anubis.Transport.StreamableHTTPTest do
         Message.encode_request(%{"method" => "ping", "params" => %{}}, "2")
 
       assert :ok = StreamableHTTP.send_message(transport, second_message, timeout: 5000)
+
+      StreamableHTTP.shutdown(transport)
+      StubClient.clear_messages()
+    end
+
+    test "forwards server-pushed events while the SSE GET is held open", %{bypass: bypass} do
+      server_url = "http://localhost:#{bypass.port}"
+      {:ok, stub_client} = StubClient.start_link()
+      session_id = "test-session-sse-push"
+
+      # POST establishes the session, which starts the SSE GET.
+      Bypass.stub(bypass, "POST", "/mcp", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.put_resp_header("mcp-session-id", session_id)
+        |> Plug.Conn.resp(200, ~s|{"jsonrpc":"2.0","id":"1","result":{}}|)
+      end)
+
+      Bypass.stub(bypass, "DELETE", "/mcp", fn conn -> Plug.Conn.resp(conn, 200, "") end)
+
+      # A held-open SSE GET that pushes a server-initiated notification and then
+      # keeps the connection open. The event must reach the client while the
+      # stream is still open — a buffering read only yields it once the stream
+      # closes, which for a real SSE stream never happens.
+      Bypass.stub(bypass, "GET", "/mcp", fn conn ->
+        conn = Plug.Conn.put_resp_header(conn, "content-type", "text/event-stream")
+        conn = Plug.Conn.send_chunked(conn, 200)
+
+        {:ok, conn} =
+          Plug.Conn.chunk(conn, """
+          data: {"jsonrpc":"2.0","method":"notifications/message","params":{"level":"info","data":"pushed"}}
+
+          """)
+
+        Process.sleep(2_000)
+        conn
+      end)
+
+      {:ok, transport} =
+        StreamableHTTP.start_link(
+          client: stub_client,
+          base_url: server_url,
+          mcp_path: "/mcp",
+          enable_sse: true,
+          transport_opts: @test_http_opts
+        )
+
+      :ok = StubClient.subscribe()
+
+      {:ok, ping} = Message.encode_request(%{"method" => "ping", "params" => %{}}, "1")
+      assert :ok = StreamableHTTP.send_message(transport, ping, timeout: 5000)
+
+      # Must arrive well inside the server's hold, proving the event is streamed
+      # rather than delivered when the connection closes. The POST response also
+      # reaches the subscriber, so wait specifically for the pushed notification.
+      assert await_pushed_notification(500), "server-pushed notification was never forwarded"
 
       StreamableHTTP.shutdown(transport)
       StubClient.clear_messages()


### PR DESCRIPTION
### Problem

A client using the `:streamable_http` transport with `enable_sse: true` never receives server-initiated messages over the long-lived `GET` SSE stream `notifications/message`, progress notifications, anything the server pushes. Request/response round-trips (tool calls) work fine, which is what makes this easy to miss: those responses close, so the buffered read returns.

### Root cause

`run_sse_task/2` reads the SSE GET through `HTTP.follow_redirect/4`, which calls `Finch.request/3`, a **buffering** read that only returns once the connection closes:

```elixir
defp process_sse_request(request, finch_name, options, parent) do
  case HTTP.follow_redirect(request, finch_name, options) do
    {:ok, %{status: 200, headers: resp_headers, body: body}} ->
      handle_sse_response(resp_headers, body, parent)   # only after close
```

For a persistent SSE stream the server holds the connection open, so `Finch.request/3` blocks indefinitely inside the SSE task, `handle_sse_response/3` never runs, and no `{:sse_event, _}` is ever sent to the transport. The parse is correct. It just never happens.

### Solution

The library already has a streaming SSE reader: `Anubis.SSE.connect/3` uses `Finch.stream_while/5` and emits parsed events as they arrive, and the `:sse` transport already consumes it exactly this way. This routes `streamable_http` through the same path rather than introducing anything new:

```elixir
defp run_sse_task(parent, state) do
  state.mcp_url
  |> URI.to_string()
  |> SSE.connect(build_sse_headers(state),
    dest: self(),
    finch_name: state.finch_name,
    transport_opts: state.transport_opts
  )
  |> Enum.each(&send(parent, {:sse_event, &1}))

  send(parent, {:sse_closed, :normal})
end
```

`process_sse_request/4` and `handle_sse_response/3` are deleted. The receiving side needs no changes — `handle_sse_event/2` already handles `%Event{}` (including `last_event_id` tracking) and `{:error, :halted}`, and `{:sse_closed, _}` already drives reconnection. Net −28 lines of transport code.

### Tradeoffs

Because `SSE.connect/3` builds its own request, the GET leg loses two things. Both are behaviour changes I'm flagging for review:

1. **Redirect following.** The GET no longer goes through `HTTP.follow_redirect`,  so a 307 on the SSE endpoint is no longer followed. The POST and DELETE legs are unchanged and still follow redirects. Note the `:sse` transport's stream has never followed redirects either, so this makes the two transports consistent — but it is a regression on this leg if anyone relies on it.
2. **The explicit 405 log branch.** `SSE.connect` halts on any non-200 status, so a server that doesn't support the SSE GET still ends the stream cleanly and `{:sse_closed, :normal}` fires as before. Only the specific `"sse_not_supported"` log line is gone.

If you'd prefer redirect support preserved on the GET, that'll mean a change to `Anubis.SSE` (shared with the `:sse` transport).

### Test

Added a test that stands up a **held-open, chunked** SSE GET (via `Plug.Conn.send_chunked/2` + `Plug.Conn.chunk/2`), pushes a `notifications/message`, then holds the connection open for 2s. The assertion waits at most 500ms for the client to forward it, so the test can only pass if the event is streamed — delivery-on-close would miss the window by 4x.

Fails before the change (the notification is never forwarded) and passes after. `mix lint` and `mix test` (939 tests) pass.