### PR TITLE
fix(sse): buffer partial SSE chunks during streaming reads

### DIFF
--- a/lib/anubis/sse.ex
+++ b/lib/anubis/sse.ex
@@ -49,7 +49,7 @@ defmodule Anubis.SSE do
       task = spawn_stream_task(req, ref, finch_name, opts)
 
       Stream.resource(
-        fn -> {ref, task} end,
+        fn -> {ref, task, ""} end,
         &process_task_stream/1,
         &shutdown_task/1
       )
@@ -127,28 +127,36 @@ defmodule Anubis.SSE do
     {:cont, acc}
   end
 
-  defp process_task_stream({ref, _task} = state) do
+  defp process_task_stream({ref, task, buffer}) do
     receive do
       {:chunk, {:data, data}, ^ref} ->
-        {Parser.run(data), state}
+        {events, remainder} = Parser.feed(buffer, data)
+        {events, {ref, task, remainder}}
 
       {:chunk, {:status, status}, ^ref} ->
         Anubis.Logging.transport_event("sse_status", status)
-        {[], state}
+        {[], {ref, task, buffer}}
 
       {:chunk, {:headers, headers}, ^ref} ->
         Anubis.Logging.transport_event("sse_headers", headers)
-        {[], state}
+        {[], {ref, task, buffer}}
 
       {:chunk, :halted, ^ref} ->
         Anubis.Logging.transport_event("sse_halted", "Transport will be restarted")
-        {[{:error, :halted}], state}
+
+        trailing_events =
+          case buffer do
+            "" -> []
+            remainder -> Parser.run(remainder)
+          end
+
+        {trailing_events ++ [{:error, :halted}], {ref, task, ""}}
 
       {:chunk, unknown, ^ref} ->
         Anubis.Logging.transport_event("sse_unknown_chunk", unknown)
-        {[], state}
+        {[], {ref, task, buffer}}
     end
   end
 
-  defp shutdown_task({_ref, task}), do: Task.shutdown(task)
+  defp shutdown_task({_ref, task, _buffer}), do: Task.shutdown(task)
 end

--- a/lib/anubis/sse/parser.ex
+++ b/lib/anubis/sse/parser.ex
@@ -35,20 +35,21 @@ defmodule Anubis.SSE.Parser do
         block = binary_part(data, 0, start)
         rest = binary_part(data, start + len, byte_size(data) - start - len)
 
-        acc =
-          if String.trim(block) == "" do
-            acc
-          else
-            case parse_event(block) do
-              %Event{data: ""} -> acc
-              event -> [event | acc]
-            end
-          end
-
-        consume(rest, acc)
+        consume(rest, append_parsed_event(acc, block))
 
       nil ->
         {Enum.reverse(acc), data}
+    end
+  end
+
+  defp append_parsed_event(acc, block) do
+    if String.trim(block) == "" do
+      acc
+    else
+      case parse_event(block) do
+        %Event{data: ""} -> acc
+        event -> [event | acc]
+      end
     end
   end
 

--- a/lib/anubis/sse/parser.ex
+++ b/lib/anubis/sse/parser.ex
@@ -3,6 +3,8 @@ defmodule Anubis.SSE.Parser do
 
   alias Anubis.SSE.Event
 
+  @event_separator ~r/(?:\r\n){2}|\n\n/
+
   @doc """
   Parses a string containing one or more SSE events.
 
@@ -11,9 +13,43 @@ defmodule Anubis.SSE.Parser do
   """
   def run(sse_data) when is_binary(sse_data) do
     sse_data
-    |> String.split(~r/\r?\n\r?\n/, trim: true)
+    |> String.split(@event_separator, trim: true)
     |> Enum.map(&parse_event/1)
     |> Enum.reject(&(&1.data == ""))
+  end
+
+  @doc """
+  Incrementally parses SSE bytes from a streaming transport.
+
+  `buffer` holds any trailing partial event from prior chunks. Returns
+  complete events and the remaining bytes to carry into the next chunk.
+  """
+  @spec feed(String.t(), String.t()) :: {[Event.t()], String.t()}
+  def feed(buffer, chunk) when is_binary(buffer) and is_binary(chunk) do
+    consume(buffer <> chunk, [])
+  end
+
+  defp consume(data, acc) do
+    case Regex.run(@event_separator, data, return: :index) do
+      [{start, len}] ->
+        block = binary_part(data, 0, start)
+        rest = binary_part(data, start + len, byte_size(data) - start - len)
+
+        acc =
+          if String.trim(block) == "" do
+            acc
+          else
+            case parse_event(block) do
+              %Event{data: ""} -> acc
+              event -> [event | acc]
+            end
+          end
+
+        consume(rest, acc)
+
+      nil ->
+        {Enum.reverse(acc), data}
+    end
   end
 
   defp parse_event(event_block) do

--- a/test/anubis/sse/parser_test.exs
+++ b/test/anubis/sse/parser_test.exs
@@ -66,6 +66,46 @@ defmodule Anubis.SSE.ParserTest do
     assert Enum.empty?(Parser.run(sse))
   end
 
+  describe "feed/2" do
+    test "returns no events until a chunk completes an SSE block" do
+      sse = "data: hello world\n\n"
+      {split_at, _} = sse |> String.graphemes() |> Enum.split(10)
+      part1 = Enum.join(split_at)
+      part2 = String.replace_prefix(sse, part1, "")
+
+      assert {[], remainder} = Parser.feed("", part1)
+      assert remainder == part1
+
+      assert {[event], ""} = Parser.feed(remainder, part2)
+      assert event.data == "hello world"
+    end
+
+    test "reassembles MCP events split across multiple chunks" do
+      assert {:ok, msg} = Message.encode_request(%{"method" => "ping"}, "req-123")
+      sse = "event: message\r\ndata: #{msg}\r\n\r\n"
+
+      split_at = String.length("event: message\r\ndata: {\"id\"")
+      part1 = binary_part(sse, 0, split_at)
+      part2 = binary_part(sse, split_at, byte_size(sse) - split_at)
+
+      assert {[], buffer} = Parser.feed("", part1)
+      assert {[event], ""} = Parser.feed(buffer, part2)
+      assert event.event == "message"
+
+      assert {:ok, [req]} = Message.decode(event.data)
+      assert req["id"] == "req-123"
+      assert req["method"] == "ping"
+    end
+
+    test "emits multiple complete events from one chunk and keeps the remainder" do
+      sse = "data: first\n\ndata: second\n\npartial"
+
+      assert {events, remainder} = Parser.feed("", sse)
+      assert Enum.map(events, & &1.data) == ["first", "second"]
+      assert remainder == "partial"
+    end
+  end
+
   describe "handles MCP message event correctly" do
     test "handles MCP endpoint event correctly" do
       sse = "event: endpoint\r\ndata: /messages/?session_id=123\r\n\r\n"


### PR DESCRIPTION
## Summary

Buffer incomplete SSE bytes across Finch transport chunks so events split across reads are reassembled before parsing.

Fixes #232

## Motivation

`Anubis.SSE.connect/3` previously called `Parser.run/1` on every `{:data, chunk}` message. Chunk boundaries are transport framing artifacts, not SSE event boundaries, so a single event written in multiple flushes could be mis-parsed or dropped.

## Changes

- Add `Parser.feed/2` for incremental SSE parsing with a carry-over buffer
- Tighten the event separator regex to `~r/(?:\r\n){2}|\n\n/` to avoid ambiguous CRLF matching
- Track `{ref, task, buffer}` in the SSE `Stream.resource/3` accumulator
- Flush any trailing buffered bytes when the stream halts
- Add unit tests for chunk-split MCP events and multi-event remainder handling

## Tests

- `mix test test/anubis/sse/parser_test.exs` — 15/15 passed
- Reviewed with composer-2.5 subagent before submission (APPROVE)

## Notes

`streamable_http.ex` paths that already receive complete SSE bodies continue to use `Parser.run/1`, which is unchanged aside from the safer separator regex.