### PR TITLE
fix(server): use restart :temporary for session processes

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -129,6 +129,16 @@ defmodule Anubis.Server.Session do
     GenServer.start_link(__MODULE__, Map.new(opts), name: name)
   end
 
+  @doc false
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :temporary,
+      type: :worker
+    }
+  end
+
   @doc """
   Auto-initializes a session without a client initialize handshake.
 

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -130,6 +130,7 @@ defmodule Anubis.Server.Session do
   end
 
   @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
   def child_spec(opts) do
     %{
       id: __MODULE__,

--- a/test/anubis/server/session_expiry_test.exs
+++ b/test/anubis/server/session_expiry_test.exs
@@ -336,4 +336,14 @@ defmodule Anubis.Server.SessionExpiryTest do
       refute state.initialized
     end
   end
+
+  describe "child_spec/1" do
+    test "uses restart: :temporary so idle expiry does not respawn an empty session" do
+      spec = Session.child_spec(session_id: "spec-test")
+
+      assert spec.restart == :temporary
+      assert spec.type == :worker
+      assert spec.start == {Session, :start_link, [[session_id: "spec-test"]]}
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Session processes now declare `restart: :temporary` so `DynamicSupervisor` does not respawn idle-expired sessions with uninitialized state under the same session ID.

## Motivation

Fixes #239. Idle expiry is an intentional lifecycle end. With the GenServer default (`:permanent`), the supervisor immediately restarted a fresh, uninitialized process that re-registered under the old session ID, causing subsequent requests to hit "Server not initialized" instead of the normal recovery path.

## Changes

- Add `Anubis.Server.Session.child_spec/1` with `restart: :temporary`
- Add unit test asserting the child spec restart strategy

## Tests

- Added `child_spec/1` unit test in `test/anubis/server/session_expiry_test.exs`
- CI expected to run full Elixir test suite

## Notes

`:temporary` is preferred over `:transient` so abnormal exits also avoid blind restarts; session recovery should happen when the next client request arrives.