### PR TITLE
fix(telemetry): namespace tool_call span under :anubis_mcp

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -800,7 +800,7 @@ defmodule Anubis.Server.Session do
     tool_name = get_in(request, ["params", "name"])
 
     :telemetry.span(
-      Telemetry.event_server_tool_call(),
+      [:anubis_mcp | Telemetry.event_server_tool_call()],
       %{tool: tool_name},
       fn -> {module.handle_request(request, frame), %{tool: tool_name}} end
     )

--- a/test/anubis/server/session_async_dispatch_test.exs
+++ b/test/anubis/server/session_async_dispatch_test.exs
@@ -217,6 +217,31 @@ defmodule Anubis.Server.SessionAsyncDispatchTest do
     end
   end
 
+  describe "tool_call telemetry" do
+    test "stop event fires under the :anubis_mcp namespace", %{session: session} do
+      handler_id = "test-tool-call-telemetry-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :telemetry.attach(
+        handler_id,
+        [:anubis_mcp, :server, :tool_call, :stop],
+        fn _event, measurements, metadata, _config ->
+          send(test_pid, {:tool_call_stop, measurements, metadata})
+        end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      ctx = with_test_pid()
+      req = tool_call_request("echo", %{"value" => "telemetry"}, "tel-1")
+      assert {:ok, _encoded} = GenServer.call(session, {:mcp_request, req, ctx}, 5_000)
+
+      assert_receive {:tool_call_stop, %{duration: duration}, %{tool: "echo"}}, 1_000
+      assert is_integer(duration) and duration >= 0
+    end
+  end
+
   defp start_async_session(_ctx) do
     session_id = "async-#{System.unique_integer([:positive])}"
     transport_name = Registry.transport_name(AsyncDispatchTestServer, StubTransport)


### PR DESCRIPTION
## Summary

Fixes #243. `Anubis.Server.Session`'s `tool_call` telemetry span was firing under `[:server, :tool_call, :start | :stop | :exception]` — without the `:anubis_mcp` namespace prefix every other server-side telemetry event in the library gets.

## Root cause

Every telemetry call site in `lib/anubis/server/session.ex` goes through `Anubis.Telemetry.execute/3`, which prepends the prefix:

```elixir
def execute(event_name, measurements, metadata) do
  :telemetry.execute([:anubis_mcp | event_name], measurements, metadata)
end
```

`Anubis.Telemetry.event_server_tool_call/0` — like every sibling `event_*` function — is documented as returning "the event name, **excluding** the `:anubis_mcp` prefix", i.e. meant to be passed through `execute/3`. The one `:telemetry.span/3` call wrapping `tools/call`, however, passed this value straight to `:telemetry.span/3`, bypassing `execute/3` entirely — so the real events fired were unprefixed.

## Fix

One-line change: prepend `:anubis_mcp` to the span's event prefix, matching every other event in the file.

```elixir
:telemetry.span(
  [:anubis_mcp | Telemetry.event_server_tool_call()],
  %{tool: tool_name},
  fn -> {module.handle_request(request, frame), %{tool: tool_name}} end
)
```

## Testing

- Added a regression test in `test/anubis/server/session_async_dispatch_test.exs` (`describe "tool_call telemetry"`) attaching to `[:anubis_mcp, :server, :tool_call, :stop]` and asserting it fires on a real `tools/call` dispatch through a live `Session`.
- Verified the new test fails without the fix (reverted the one-line change locally, test failed with "no matching message after 1000ms" — the unprefixed event doesn't match) and passes with it.
- Full suite: `mix test` → 941 tests, 35 doctests, 0 failures.
- `mix lint` (format --check-formatted, credo --strict, dialyzer) → clean.

## Impact

Any application instrumenting Anubis's native telemetry via the documented `[:anubis_mcp | ...]` convention would silently receive zero tool-call metrics/spans while correctly receiving every other server event (`request`, `response`, `error`, `init`, etc) — no error, no warning, just a metric that never fires. Discovered while wiring Datadog metrics for tool-call latency in a downstream application.
