### PR TITLE
fix(telemetry): expose tool call success/failure in tool_call span metadata

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -802,13 +802,20 @@ defmodule Anubis.Server.Session do
     :telemetry.span(
       Telemetry.event_server_tool_call(),
       %{tool: tool_name},
-      fn -> {module.handle_request(request, frame), %{tool: tool_name}} end
+      fn ->
+        result = module.handle_request(request, frame)
+        {result, %{tool: tool_name, is_error: tool_call_error?(result)}}
+      end
     )
   end
 
   defp do_handle_request(module, request, frame, _method) do
     module.handle_request(request, frame)
   end
+
+  defp tool_call_error?({:error, _reason, _frame}), do: true
+  defp tool_call_error?({:reply, %{"isError" => true}, _frame}), do: true
+  defp tool_call_error?(_result), do: false
 
   # Async dispatch helpers
 

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -633,6 +633,75 @@ defmodule Anubis.Server.SessionTest do
     end
   end
 
+  describe "tool_call telemetry :is_error metadata" do
+    setup do
+      test_pid = self()
+      handler_id = "test-tool-call-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        # NOTE: currently unprefixed (missing the :anubis_mcp namespace) — see #243/#244.
+        [:server, :tool_call, :stop],
+        fn _e, _m, meta, _c -> send(test_pid, {:tool_call_stop, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      transport_name = Registry.transport_name(TasksStubServer, StubTransport)
+      start_supervised!({StubTransport, name: transport_name})
+      task_sup = Registry.task_supervisor_name(TasksStubServer)
+      start_supervised!({Task.Supervisor, name: task_sup})
+
+      session_id = "tool-call-telemetry-#{System.unique_integer([:positive])}"
+      session_name = Registry.session_name(TasksStubServer, session_id)
+
+      session =
+        start_supervised!(
+          {Session,
+           session_id: session_id,
+           server_module: TasksStubServer,
+           name: session_name,
+           transport: [layer: StubTransport, name: transport_name],
+           task_supervisor: task_sup}
+        )
+
+      init_msg = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, init_msg, %{}})
+
+      init_notification = build_notification("notifications/initialized", %{})
+      assert :ok = GenServer.cast(session, {:mcp_notification, init_notification, %{}})
+
+      %{session: session}
+    end
+
+    test "is_error is false for a successful tool call", %{session: session} do
+      request = build_request("tools/call", %{"name" => "no_tasks", "arguments" => %{}}, 1)
+
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, request, %{}})
+      assert_receive {:tool_call_stop, %{tool: "no_tasks", is_error: false}}, 500
+    end
+
+    test "is_error is true when the tool itself reports a CallToolResult error", %{session: session} do
+      request =
+        build_request(
+          "tools/call",
+          %{"name" => "always_fails", "arguments" => %{"reason" => "boom"}},
+          2
+        )
+
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, request, %{}})
+      assert_receive {:tool_call_stop, %{tool: "always_fails", is_error: true}}, 500
+    end
+
+    test "is_error is true when the tool is not found (protocol-level error)", %{session: session} do
+      request = build_request("tools/call", %{"name" => "nonexistent_tool"}, 3)
+
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, request, %{}})
+      assert_receive {:tool_call_stop, %{tool: "nonexistent_tool", is_error: true}}, 500
+    end
+  end
+
   describe "terminate/2 on supervisor-initiated stop" do
     defp start_supervised_session(server_module, session_id) do
       transport_name = Registry.transport_name(server_module, StubTransport)


### PR DESCRIPTION
## Problem

The `tool_call` telemetry span (`do_handle_request/4` for `"tools/call"` requests) always emits the same `:stop` metadata, `%{tool: tool_name}`, regardless of whether the wrapped call succeeded, returned a protocol-level error (e.g. tool not found, invalid params), or returned a `CallToolResult` with `isError: true`.

The actual result of `module.handle_request(request, frame)` is available inside the span function, but it is discarded before being turned into span metadata — a telemetry handler attached to this event has no way to tell a successful tool call apart from a failed one without independently re-deriving that information elsewhere (e.g. by separately handling `[:anubis_mcp, :server, :error]`, which only fires for protocol-level errors, not for tool-level `isError: true` results).

## Solution

Bind the result of `module.handle_request(request, frame)` and derive an `is_error` boolean from it before it becomes span metadata:

- `{:error, _reason, _frame}` (protocol-level error) → `is_error: true`
- `{:reply, %{"isError" => true}, _frame}` (tool-level error via `Response.error/2`) → `is_error: true`
- anything else → `is_error: false`

Added three regression tests covering all three branches (successful call, tool-level `isError: true`, protocol-level tool-not-found), attached directly to the `tool_call` `:stop` telemetry event.

## Rationale

This was the smallest possible change that surfaces the missing signal: the result is already computed and in scope inside the span closure, so no additional work is done, only a cheap pattern match on a value that already exists. No public API, return value, or behavior changes — this only adds a new key to telemetry metadata, which is additive and non-breaking for existing handlers.

I kept the derivation as a private function (`tool_call_error?/1`) rather than inlining it, since the two failure shapes it distinguishes (protocol error vs. tool-level `isError`) are exactly the two failure modes the MCP spec itself defines, and a named predicate makes that mapping explicit rather than embedding it in the span call.

Related to #243 (unprefixed event name) but independent — this PR does not touch the event namespace, only the `:stop` metadata shape. Happy to rebase on top of #244 if that merges first.