### PR TITLE
fix(telemetry): include client_info in initialize response event metadata

### DIFF
--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -715,7 +715,7 @@ defmodule Anubis.Server.Session do
     Telemetry.execute(
       Telemetry.event_server_response(),
       %{system_time: System.system_time()},
-      %{method: "initialize", status: :success}
+      %{method: "initialize", status: :success, client_info: client_info}
     )
 
     {:reply, {:ok, encode_reply(Message.build_response(result, request["id"]))}, state}

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -107,7 +107,7 @@ defmodule Anubis.Server.SessionTest do
 
       :telemetry.attach(
         handler_id,
-        [:anubis_mcp, :server, :response],
+        [:anubis_mcp | Anubis.Telemetry.event_server_response()],
         fn _e, _m, meta, _c -> send(test_pid, {:server_response, meta}) end,
         nil
       )

--- a/test/anubis/server/session_test.exs
+++ b/test/anubis/server/session_test.exs
@@ -100,6 +100,48 @@ defmodule Anubis.Server.SessionTest do
     end
   end
 
+  describe "initialize telemetry" do
+    test "response event metadata carries client_info" do
+      test_pid = self()
+      handler_id = "test-init-telemetry-#{System.unique_integer([:positive])}"
+
+      :telemetry.attach(
+        handler_id,
+        [:anubis_mcp, :server, :response],
+        fn _e, _m, meta, _c -> send(test_pid, {:server_response, meta}) end,
+        nil
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      transport_name = Registry.transport_name(StubServer, StubTransport)
+      start_supervised!({StubTransport, name: transport_name})
+      task_sup = Registry.task_supervisor_name(StubServer)
+      start_supervised!({Task.Supervisor, name: task_sup})
+
+      session_id = "init_telemetry_session_#{System.unique_integer()}"
+      session_name = Registry.session_name(StubServer, session_id)
+
+      session =
+        start_supervised!(
+          {Session,
+           session_id: session_id,
+           server_module: StubServer,
+           name: session_name,
+           transport: [layer: StubTransport, name: transport_name],
+           task_supervisor: task_sup},
+          id: :init_telemetry_session
+        )
+
+      client_info = %{"name" => "TestClient", "version" => "1.0.0"}
+      init_msg = init_request("2025-03-26", client_info)
+
+      assert {:ok, _} = GenServer.call(session, {:mcp_request, init_msg, %{}})
+
+      assert_receive {:server_response, %{method: "initialize", status: :success, client_info: ^client_info}}, 500
+    end
+  end
+
   describe "handle_call/3 for messages" do
     setup :initialized_server
 


### PR DESCRIPTION
## Problem

The `[:anubis_mcp, :server, :response]` telemetry event fired after a successful `initialize` request only carries `%{method: "initialize", status: :success}` as metadata. `client_info` (the client's self-reported `name`/`version` from the MCP handshake) is already parsed and bound in scope at that exact call site — it's used moments earlier to build session state and to log an `"initializing"` event — but it never makes it into the telemetry metadata.

This makes it impossible for a telemetry handler to know which client connected (by name/version) without separately re-deriving it from logs or session state. For anyone building observability on top of Anubis (e.g. tracking which integrations/agents are using a given MCP server), this is a real gap: `initialize` is the one point in the protocol where the client actively identifies itself, and that identity is silently dropped before telemetry ever sees it.

## Solution

Add `client_info: client_info` to the existing metadata map passed to `Telemetry.execute/3` in the `initialize` handler. No new event, no signature changes, no behavior changes to anything else — purely additive metadata on an event that already fires.

Added a regression test that attaches directly to `[:anubis_mcp, :server, :response]`, drives a real `initialize` request through a session, and asserts `client_info` flows through end-to-end (not just a unit-level check on the call site).

## Rationale

This is the smallest possible fix: the value was already computed and in scope, so this is a one-line addition to a map literal, no new computation, no new event. I scoped it strictly to the `initialize` response event rather than also touching the async-dispatch `decode_task_result/3` clauses (which fire this same event for every subsequent request) — those clauses only have `inflight`/`state` in scope, and while `state.client_info` is available there too, doing so would widen this PR beyond a single, easily-reviewable change. Happy to follow up with a second PR extending this to per-request events if that's wanted, but felt out of scope for the initial connection-identity gap this PR closes.