### PR TITLE
fix: encode resource blobs as standard base64

### DIFF
--- a/lib/anubis/server/response.ex
+++ b/lib/anubis/server/response.ex
@@ -492,7 +492,11 @@ defmodule Anubis.Server.Response do
       %Response{type: :resource, contents: %{"blob" => base64_data}}
   """
   def blob(%{type: :resource} = r, data) when is_binary(data) do
-    %{r | contents: %{"blob" => Base.url_encode64(data, padding: false)}}
+    # Standard base64 with padding, per the MCP schema's `BlobResourceContents`.
+    # NOT `url_encode64/2`: the URL-safe alphabet substitutes `-` and `_` for `+`
+    # and `/`, and dropping padding leaves a length no strict decoder accepts, so
+    # any binary resource carrying those bytes fails validation client-side.
+    %{r | contents: %{"blob" => Base.encode64(data)}}
   end
 
   @doc """

--- a/lib/anubis/server/response.ex
+++ b/lib/anubis/server/response.ex
@@ -491,6 +491,7 @@ defmodule Anubis.Server.Response do
       iex> Response.resource() |> Response.blob(data)
       %Response{type: :resource, contents: %{"blob" => base64_data}}
   """
+  @spec blob(t, binary) :: t
   def blob(%{type: :resource} = r, data) when is_binary(data) do
     # Standard base64 with padding, per the MCP schema's `BlobResourceContents`.
     # NOT `url_encode64/2`: the URL-safe alphabet substitutes `-` and `_` for `+`

--- a/test/anubis/server/response_test.exs
+++ b/test/anubis/server/response_test.exs
@@ -395,6 +395,33 @@ defmodule Anubis.Server.ResponseTest do
              } = result
     end
 
+    test "blob is standard base64 the spec's decoder accepts" do
+      # Bytes chosen so the encoding differs between the two alphabets: this
+      # payload produces `+` and `/` under standard base64 and `-` and `_` under
+      # the URL-safe one, so a URL-safe encoder fails `Base.decode64/1` here.
+      data = <<0xFF, 0xEF, 0xBE, 0x00, 0x01, 0x02>>
+
+      %{"blob" => blob} =
+        Response.resource()
+        |> Response.blob(data)
+        |> Response.to_protocol("file://binary.bin", "application/octet-stream")
+
+      assert {:ok, ^data} = Base.decode64(blob)
+      refute String.contains?(blob, ["-", "_"])
+      assert rem(byte_size(blob), 4) == 0
+    end
+
+    test "blob round-trips arbitrary binary content" do
+      data = :crypto.strong_rand_bytes(257)
+
+      %{"blob" => blob} =
+        Response.resource()
+        |> Response.blob(data)
+        |> Response.to_protocol("file://random.bin", "application/octet-stream")
+
+      assert {:ok, ^data} = Base.decode64(blob)
+    end
+
     test "builds a resource with metadata" do
       result =
         Response.resource()


### PR DESCRIPTION
`Response.blob/2` encodes binary resource content with `Base.url_encode64(data, padding: false)`:

```elixir
def blob(%{type: :resource} = r, data) when is_binary(data) do
  %{r | contents: %{"blob" => Base.url_encode64(data, padding: false)}}
end
```

The MCP schema types `BlobResourceContents.blob` as base64, meaning the standard alphabet. The URL-safe variant substitutes `-` and `_` for `+` and `/`, and `padding: false` leaves a length that a strict decoder rejects.

### Impact

Any binary resource whose bytes encode to a `+` or `/` fails validation on the client, before the payload is ever seen. In practice a server cannot return PDFs, images, or other binary content to a spec-compliant client at all — the failure surfaces as a schema error on `contents[0]`, with `text` undefined and `blob" not valid base64, which is confusing to trace back to the encoder.

### The change

`Base.encode64/1`. `blob/2` is the only producer of the field and nothing in the library decodes it, so the change is contained. The other `url_encode64` call sites (`Anubis.MCP.ID`, `Anubis.Server.Task`) are internal opaque identifiers where the URL-safe alphabet is appropriate and are left alone.

### Tests

The existing test asserted only `"blob" => _`, which passes under either alphabet — that is why this went unnoticed. Added two that fail against the previous implementation:

- one using bytes whose encodings differ between the alphabets, also asserting the result contains no `-`/`_` and is a multiple of 4
- one round-tripping 257 random bytes through `Base.decode64/1`

Full suite passes (1038 tests).