### PR TITLE
feat(server): serve the 2026-07-28 stateless era

### DIFF
--- a/lib/anubis/mcp/error.ex
+++ b/lib/anubis/mcp/error.ex
@@ -260,6 +260,25 @@ defmodule Anubis.MCP.Error do
   end
 
   @doc """
+  Creates a resource-not-found error for a protocol era.
+
+  Revision 2026-07-28 reallocates this condition from the MCP-specific
+  `-32002` to the JSON-RPC `-32602`, and reserves `-32002` so it is never
+  reused. Legacy eras keep the code they shipped with.
+
+  ## Examples
+
+      iex> Anubis.MCP.Error.resource_not_found(%{uri: "file:///missing.txt"}, :legacy).code
+      -32002
+
+      iex> Anubis.MCP.Error.resource_not_found(%{uri: "file:///missing.txt"}, :stateless).code
+      -32602
+  """
+  @spec resource_not_found(map(), Anubis.Protocol.Behaviour.era()) :: t()
+  def resource_not_found(data, :stateless), do: protocol(:invalid_params, data)
+  def resource_not_found(data, _era), do: resource(:not_found, data)
+
+  @doc """
   Creates a resource-specific error.
 
   Used for MCP resource operations.

--- a/lib/anubis/mcp/message.ex
+++ b/lib/anubis/mcp/message.ex
@@ -279,7 +279,7 @@ defmodule Anubis.MCP.Message do
   defp schema_module(%{"params" => %{"_meta" => %{@protocol_version_key => version}}}) when is_binary(version) do
     case Registry.get(version) do
       {:ok, protocol_module} -> protocol_module
-      :error -> Registry.latest_module(:stateless)
+      :error -> Registry.latest_module(:stateless) || Registry.latest_module()
     end
   end
 

--- a/lib/anubis/mcp/message.ex
+++ b/lib/anubis/mcp/message.ex
@@ -11,9 +11,12 @@ defmodule Anubis.MCP.Message do
   """
 
   alias Anubis.Protocol.Registry
+  alias Anubis.Protocol.Schema
   alias Anubis.Protocol.V2025_03_26
 
   @log_levels ~w(debug info notice warning error critical alert emergency)
+
+  @protocol_version_key Schema.protocol_version_key()
 
   # Progress notification schema exposed for the encode helpers, single-sourced
   # from the floor protocol version module.
@@ -233,12 +236,26 @@ defmodule Anubis.MCP.Message do
   @doc """
   Decodes raw data (possibly containing multiple messages) into JSON-RPC messages.
 
-  Messages are validated against the latest registered protocol version.
+  Each message is validated against the era it declares: a message carrying a
+  protocol version in `params._meta` is validated against that version's
+  module, everything else against the latest registered version, which
+  preserves the previous superset behavior.
+
+  A message declaring a version this build does not register is validated
+  against the newest stateless version instead of being rejected here, so the
+  peer can answer it with the `UnsupportedProtocolVersion` error the
+  specification requires.
+
   Returns either:
   - `{:ok, messages}` where messages is a list of parsed JSON-RPC messages
   - `{:error, reason}` if parsing fails
   """
-  def decode(data), do: decode(data, Registry.latest_module())
+  @spec decode(binary()) :: {:ok, [map()]} | {:error, atom()}
+  def decode(data) when is_binary(data) do
+    data
+    |> split_lines()
+    |> validate_all_messages(&schema_module/1)
+  end
 
   @doc """
   Decodes raw data, validating each message against the given protocol
@@ -246,17 +263,27 @@ defmodule Anubis.MCP.Message do
 
   Returns the same shapes as `decode/1`.
   """
+  @spec decode(binary(), module()) :: {:ok, [map()]} | {:error, atom()}
   def decode(data, protocol_module) when is_binary(data) do
     data
-    |> String.split("\n", trim: true)
-    |> decode_lines(protocol_module)
+    |> split_lines()
+    |> validate_all_messages(fn _message -> protocol_module end)
   end
 
-  defp decode_lines(lines, protocol_module) do
-    lines
+  defp split_lines(data) do
+    data
+    |> String.split("\n", trim: true)
     |> Enum.flat_map(&decode_line/1)
-    |> validate_all_messages(protocol_module)
   end
+
+  defp schema_module(%{"params" => %{"_meta" => %{@protocol_version_key => version}}}) when is_binary(version) do
+    case Registry.get(version) do
+      {:ok, protocol_module} -> protocol_module
+      :error -> Registry.latest_module(:stateless)
+    end
+  end
+
+  defp schema_module(_message), do: Registry.latest_module()
 
   defp decode_line(line) do
     case JSON.decode(line) do
@@ -266,14 +293,14 @@ defmodule Anubis.MCP.Message do
     end
   end
 
-  defp validate_all_messages(messages, protocol_module) do
+  defp validate_all_messages(messages, module_fun) do
     messages
     |> Enum.reduce_while({:ok, []}, fn
       {:invalid, reason}, _acc ->
         {:halt, {:error, reason}}
 
       message, {:ok, acc} ->
-        case validate_message(message, protocol_module) do
+        case validate_message(message, module_fun.(message)) do
           {:ok, validated} -> {:cont, {:ok, [validated | acc]}}
           error -> {:halt, error}
         end

--- a/lib/anubis/protocol/registry.ex
+++ b/lib/anubis/protocol/registry.ex
@@ -165,6 +165,18 @@ defmodule Anubis.Protocol.Registry do
   def latest_module, do: @versions[@latest_version]
 
   @doc """
+  Returns the module for the latest supported version of an era, or `nil` when
+  the era has no registered version.
+
+  ## Examples
+
+      iex> Anubis.Protocol.Registry.latest_module(:stateless)
+      Anubis.Protocol.V2026_07_28
+  """
+  @spec latest_module(era()) :: module() | nil
+  def latest_module(era), do: @versions[latest_version(era)]
+
+  @doc """
   Check if a version string is supported.
   """
   @spec supported?(version()) :: boolean()

--- a/lib/anubis/protocol/schema.ex
+++ b/lib/anubis/protocol/schema.ex
@@ -34,6 +34,8 @@ defmodule Anubis.Protocol.Schema do
 
   @subscription_id_key "io.modelcontextprotocol/subscriptionId"
 
+  @protocol_version_key "io.modelcontextprotocol/protocolVersion"
+
   @doc """
   Returns the schema fragment for the `params._meta.progressToken` slot
   shared by all MCP requests.
@@ -61,6 +63,21 @@ defmodule Anubis.Protocol.Schema do
   """
   @spec log_levels() :: [String.t()]
   def log_levels, do: @log_levels
+
+  @doc """
+  Returns the `_meta` key a stateless-era request declares its protocol
+  version under.
+
+  It is the key that tells a dual-era peer which era a message belongs to, so
+  it is resolved from here rather than restated wherever that decision is made.
+
+  ## Examples
+
+      iex> Anubis.Protocol.Schema.protocol_version_key()
+      "io.modelcontextprotocol/protocolVersion"
+  """
+  @spec protocol_version_key() :: String.t()
+  def protocol_version_key, do: @protocol_version_key
 
   @doc """
   Merges the stateless-era per-request `_meta` slot into a params schema map.
@@ -170,9 +187,9 @@ defmodule Anubis.Protocol.Schema do
   end
 
   defp validate_protocol_version(meta) do
-    case Map.get(meta, "io.modelcontextprotocol/protocolVersion") do
+    case Map.get(meta, @protocol_version_key) do
       version when is_binary(version) -> :ok
-      _ -> {:error, "_meta is missing required key %{key}", key: "io.modelcontextprotocol/protocolVersion"}
+      _ -> {:error, "_meta is missing required key %{key}", key: @protocol_version_key}
     end
   end
 

--- a/lib/anubis/protocol/v2026_07_28.ex
+++ b/lib/anubis/protocol/v2026_07_28.ex
@@ -80,6 +80,15 @@ defmodule Anubis.Protocol.V2026_07_28 do
     "requestState" => :string
   }
 
+  @discover_result_schema %{
+    "resultType" => {:required, {:literal, "complete"}},
+    "supportedVersions" => {:required, {:list, :string}},
+    "capabilities" => {:required, :map},
+    "instructions" => :string,
+    "ttlMs" => {:required, {:integer, {:gte, 0}}},
+    "cacheScope" => {:required, {:enum, ~w(public private)}}
+  }
+
   @impl true
   def era, do: @era
 
@@ -110,6 +119,8 @@ defmodule Anubis.Protocol.V2026_07_28 do
   def progress_params_schema, do: V2025_06_18.progress_params_schema()
 
   @impl true
+  def request_result_schema("server/discover"), do: @discover_result_schema
+
   def request_result_schema(_method), do: nil
 
   @impl true

--- a/lib/anubis/server/context.ex
+++ b/lib/anubis/server/context.ex
@@ -32,6 +32,20 @@ defmodule Anubis.Server.Context do
   request params (the MCP extension namespace), available to every callback
   including `init/2`. Empty map when the client sent none. Metadata sent under
   `clientInfo._meta` is preserved inside `client_info` itself.
+
+  ## Protocol era fields
+
+  `protocol_version`, `protocol_module`, `client_capabilities` and `log_level`
+  describe the protocol the current request speaks.
+
+  Under the `:legacy` era they are settled once by the `initialize` handshake
+  and hold for the session. Under the `:stateless` era every request carries
+  its own, so they are rebuilt per request and never inherited — the
+  specification forbids a server from inferring capabilities from earlier
+  requests. `client_info` follows the same rule.
+
+  They are `nil` (and `client_capabilities` empty) before a legacy session has
+  been initialized.
   """
 
   @type auth_claims :: %{
@@ -51,7 +65,11 @@ defmodule Anubis.Server.Context do
           init_meta: map(),
           headers: %{String.t() => String.t()},
           remote_ip: :inet.ip_address() | nil,
-          auth: auth_claims() | nil
+          auth: auth_claims() | nil,
+          protocol_version: String.t() | nil,
+          protocol_module: module() | nil,
+          client_capabilities: map(),
+          log_level: String.t() | nil
         }
 
   defstruct session_id: nil,
@@ -59,5 +77,9 @@ defmodule Anubis.Server.Context do
             init_meta: %{},
             headers: %{},
             remote_ip: nil,
-            auth: nil
+            auth: nil,
+            protocol_version: nil,
+            protocol_module: nil,
+            client_capabilities: %{},
+            log_level: nil
 end

--- a/lib/anubis/server/handlers.ex
+++ b/lib/anubis/server/handlers.ex
@@ -8,6 +8,7 @@ defmodule Anubis.Server.Handlers do
   alias Anubis.Server.Handlers.Resources
   alias Anubis.Server.Handlers.Tools
   alias Anubis.Server.Response
+  alias Anubis.Server.Stateless
 
   @spec handle(map, module, Frame.t()) ::
           {:reply, response :: Response.t(), new_state :: Frame.t()}
@@ -37,6 +38,14 @@ defmodule Anubis.Server.Handlers do
       "subscribe" -> Resources.handle_subscribe(request, frame, module)
       "unsubscribe" -> Resources.handle_unsubscribe(request, frame, module)
       _ -> {:error, Error.protocol(:method_not_found, %{method: request["method"]}), frame}
+    end
+  end
+
+  def handle(%{"method" => "server/discover"} = request, module, %Frame{context: context} = frame) do
+    if Stateless.era(context.protocol_module) == :stateless do
+      {:reply, Stateless.discover_result(module, context.protocol_module), frame}
+    else
+      {:error, Error.protocol(:method_not_found, %{method: request["method"]}), frame}
     end
   end
 

--- a/lib/anubis/server/handlers/resources.ex
+++ b/lib/anubis/server/handlers/resources.ex
@@ -7,6 +7,7 @@ defmodule Anubis.Server.Handlers.Resources do
   alias Anubis.Server.Frame
   alias Anubis.Server.Handlers
   alias Anubis.Server.Response
+  alias Anubis.Server.Stateless
 
   @spec handle_list(map, Frame.t(), module()) ::
           {:reply, map(), Frame.t()} | {:error, Error.t(), Frame.t()}
@@ -138,7 +139,7 @@ defmodule Anubis.Server.Handlers.Resources do
 
   defp try_resource_templates([], _server, uri, frame, nil) do
     payload = %{message: "Resource not found: #{uri}"}
-    error = Error.resource(:not_found, payload)
+    error = Error.resource_not_found(payload, Stateless.era(frame.context.protocol_module))
     {:error, error, frame}
   end
 

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -370,6 +370,9 @@ defmodule Anubis.Server.Session do
 
   # A request declaring its own protocol version is admitted per request, and
   # its context travels with the transport context rather than session state.
+  # Notifications cannot declare a version — the stateless era gives them a
+  # `_meta` without one — so their era travels with the transport binding that
+  # opened the connection, and admitting them waits for it.
   defp admit_request(decoded, transport_context, state) do
     if Stateless.request?(decoded) do
       with {:ok, context} <- Stateless.admit(decoded, state.supported_versions),

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -25,6 +25,7 @@ defmodule Anubis.Server.Session do
   alias Anubis.Server.Session.Scheduler
   alias Anubis.Server.Session.ServerRequests
   alias Anubis.Server.Session.Tasks
+  alias Anubis.Server.Stateless
   alias Anubis.Telemetry
 
   require Message
@@ -211,9 +212,12 @@ defmodule Anubis.Server.Session do
     state = merge_transport_assigns(state, transport_context)
     state = reset_session_expiry(state)
 
-    case revalidate_for_version(decoded, state) do
-      {:ok, decoded} ->
+    case admit_request(decoded, transport_context, state) do
+      {:ok, decoded, transport_context} ->
         handle_single_request(decoded, transport_context, from, state)
+
+      {:error, %Error{} = error} ->
+        {:reply, {:ok, encode_reply(Error.build_json_rpc(error, decoded["id"]))}, state}
 
       {:error, reason} ->
         error = Error.protocol(reason, %{method: decoded["method"]})
@@ -361,6 +365,21 @@ defmodule Anubis.Server.Session do
       })
 
       {:noreply, state}
+    end
+  end
+
+  # A request declaring its own protocol version is admitted per request, and
+  # its context travels with the transport context rather than session state.
+  defp admit_request(decoded, transport_context, state) do
+    if Stateless.request?(decoded) do
+      with {:ok, context} <- Stateless.admit(decoded, state.supported_versions),
+           {:ok, decoded} <- Message.validate_message(decoded, context.protocol_module) do
+        {:ok, decoded, Stateless.put_context(transport_context, context)}
+      end
+    else
+      with {:ok, decoded} <- revalidate_for_version(decoded, state) do
+        {:ok, decoded, transport_context}
+      end
     end
   end
 
@@ -621,7 +640,7 @@ defmodule Anubis.Server.Session do
       Message.is_ping(decoded) ->
         handle_server_ping(decoded, state)
 
-      not is_server_initialized(decoded, state) ->
+      not ready_for?(decoded, transport_context, state) ->
         handle_server_not_initialized(decoded, state)
 
       Message.is_request(decoded) ->
@@ -630,6 +649,10 @@ defmodule Anubis.Server.Session do
       true ->
         handle_invalid_request(state)
     end
+  end
+
+  defp ready_for?(decoded, transport_context, state) do
+    is_server_initialized(decoded, state) or not is_nil(Stateless.context(transport_context))
   end
 
   defp handle_server_ping(%{"id" => request_id}, state) do
@@ -659,16 +682,8 @@ defmodule Anubis.Server.Session do
 
   # Initialize handling
 
-  defp handle_request(%{"params" => params} = request, _transport_context, _from, state)
-       when Message.is_initialize(request) do
-    %{
-      "clientInfo" => client_info,
-      "capabilities" => client_capabilities,
-      "protocolVersion" => requested_version
-    } = params
-
-    {:ok, protocol_version, protocol_module} =
-      Anubis.Protocol.Registry.negotiate(requested_version, state.supported_versions)
+  defp complete_initialize(request, params, {protocol_version, protocol_module}, state) do
+    %{"clientInfo" => client_info, "capabilities" => client_capabilities} = params
 
     state = %{
       state
@@ -706,6 +721,22 @@ defmodule Anubis.Server.Session do
     )
 
     {:reply, {:ok, encode_reply(Message.build_response(result, request["id"]))}, state}
+  end
+
+  defp handle_request(%{"params" => params} = request, _transport_context, _from, state)
+       when Message.is_initialize(request) do
+    %{"protocolVersion" => requested_version} = params
+
+    case Anubis.Protocol.Registry.negotiate(requested_version, state.supported_versions) do
+      {:ok, protocol_version, protocol_module} ->
+        complete_initialize(request, params, {protocol_version, protocol_module}, state)
+
+      :error ->
+        error =
+          Error.unsupported_protocol_version(requested_version, Stateless.supported_versions(state.supported_versions))
+
+        {:reply, {:ok, encode_reply(Error.build_json_rpc(error, request["id"]))}, state}
+    end
   end
 
   defp handle_request(%{"id" => request_id, "method" => "logging/setLevel"} = request, _transport_context, _from, state)
@@ -827,10 +858,27 @@ defmodule Anubis.Server.Session do
       init_meta: state.init_meta,
       headers: headers,
       remote_ip: remote_ip,
-      auth: auth
+      auth: auth,
+      protocol_version: state.protocol_version,
+      protocol_module: state.protocol_module,
+      client_capabilities: state.client_capabilities || %{},
+      log_level: state.log_level
     }
 
-    %{state.frame | context: context}
+    %{state.frame | context: apply_stateless_context(context, Stateless.context(transport_context))}
+  end
+
+  defp apply_stateless_context(context, nil), do: context
+
+  defp apply_stateless_context(context, stateless) do
+    %{
+      context
+      | protocol_version: stateless.protocol_version,
+        protocol_module: stateless.protocol_module,
+        client_capabilities: stateless.client_capabilities,
+        client_info: stateless.client_info,
+        log_level: stateless.log_level
+    }
   end
 
   defp merge_transport_assigns(state, %{assigns: assigns}) when is_map(assigns) do

--- a/lib/anubis/server/session/scheduler.ex
+++ b/lib/anubis/server/session/scheduler.ex
@@ -9,6 +9,7 @@ defmodule Anubis.Server.Session.Scheduler do
   alias Anubis.MCP.Error
   alias Anubis.MCP.Message
   alias Anubis.Server.Frame
+  alias Anubis.Server.Stateless
   alias Anubis.Telemetry
 
   @type in_flight :: %{
@@ -17,7 +18,8 @@ defmodule Anubis.Server.Session.Scheduler do
           request_id: String.t(),
           from: GenServer.from(),
           started_at: integer(),
-          method: String.t()
+          method: String.t(),
+          stateless: Stateless.t() | nil
         }
 
   @type queued_request :: {map(), map(), GenServer.from()}
@@ -176,7 +178,8 @@ defmodule Anubis.Server.Session.Scheduler do
           request_id: request_id,
           from: from,
           started_at: System.monotonic_time(:millisecond),
-          method: method
+          method: method,
+          stateless: Stateless.context(transport_context)
         }
     }
   end
@@ -201,6 +204,7 @@ defmodule Anubis.Server.Session.Scheduler do
       %{id: inflight.request_id, method: inflight.method, status: :success}
     )
 
+    response = shape_response(response, inflight, state)
     reply = {:ok, encode_reply(Message.build_response(response, inflight.request_id))}
     {reply, %{state | frame: frame}}
   end
@@ -249,6 +253,14 @@ defmodule Anubis.Server.Session.Scheduler do
     reply = {:ok, encode_reply(Error.build_json_rpc(error, inflight.request_id))}
     {reply, state}
   end
+
+  defp shape_response(response, %{stateless: nil}, _state), do: response
+
+  defp shape_response(response, _inflight, state) when is_map(response) and not is_struct(response) do
+    Stateless.shape_result(response, state.server_info)
+  end
+
+  defp shape_response(response, _inflight, _state), do: response
 
   defp drain_deferred_callbacks(%{deferred_callbacks: q} = state, apply_fn) do
     state = %{state | deferred_callbacks: :queue.new()}

--- a/lib/anubis/server/session/server_requests.ex
+++ b/lib/anubis/server/session/server_requests.ex
@@ -281,7 +281,7 @@ defmodule Anubis.Server.Session.ServerRequests do
     if Map.has_key?(state.client_capabilities || %{}, capability) do
       :ok
     else
-      {:error, "Client does not support #{capability} capability"}
+      {:error, Error.missing_required_client_capability(%{capability => %{}})}
     end
   end
 

--- a/lib/anubis/server/stateless.ex
+++ b/lib/anubis/server/stateless.ex
@@ -110,6 +110,9 @@ defmodule Anubis.Server.Stateless do
   not serve the requested version, carrying the versions the client may retry
   with.
 
+  Only defined for a message `request?/1` accepts; any other shape is a caller
+  error and raises.
+
   ## Examples
 
       iex> meta = %{

--- a/lib/anubis/server/stateless.ex
+++ b/lib/anubis/server/stateless.ex
@@ -1,0 +1,257 @@
+defmodule Anubis.Server.Stateless do
+  @moduledoc """
+  Serving requests of the `:stateless` protocol era.
+
+  Versions in this era (MCP 2026-07-28 onward) have no `initialize` handshake:
+  every request carries its own protocol version, client capabilities and
+  client identity under the reserved `io.modelcontextprotocol/*` keys of
+  `params._meta`. A request bearing that metadata is what tells a dual-era
+  server to serve it statelessly.
+
+  Because the specification forbids inferring capabilities from earlier
+  requests, `admit/2` returns a context that lives only for the request that
+  produced it. Nothing here writes to session state.
+  """
+
+  alias Anubis.MCP.Error
+  alias Anubis.Protocol.Registry
+  alias Anubis.Protocol.Schema
+
+  @protocol_version_key Schema.protocol_version_key()
+  @client_capabilities_key "io.modelcontextprotocol/clientCapabilities"
+  @client_info_key "io.modelcontextprotocol/clientInfo"
+  @log_level_key "io.modelcontextprotocol/logLevel"
+  @server_info_key "io.modelcontextprotocol/serverInfo"
+
+  @discover_ttl_ms 0
+  @discover_cache_scope "private"
+
+  @type t :: %{
+          protocol_version: String.t(),
+          protocol_module: module(),
+          client_capabilities: map(),
+          client_info: map() | nil,
+          log_level: String.t() | nil
+        }
+
+  @doc """
+  Returns the era a request served by `protocol_module` belongs to.
+
+  `nil` means no version has been settled yet, which happens only before a
+  legacy handshake completes.
+
+  ## Examples
+
+      iex> Anubis.Server.Stateless.era(Anubis.Protocol.V2026_07_28)
+      :stateless
+
+      iex> Anubis.Server.Stateless.era(nil)
+      :legacy
+  """
+  @spec era(module() | nil) :: Anubis.Protocol.Behaviour.era()
+  def era(nil), do: :legacy
+  def era(protocol_module), do: protocol_module.era()
+
+  @doc """
+  Returns the key a stateless result carries the server identity under.
+
+  ## Examples
+
+      iex> Anubis.Server.Stateless.server_info_key()
+      "io.modelcontextprotocol/serverInfo"
+  """
+  @spec server_info_key() :: String.t()
+  def server_info_key, do: @server_info_key
+
+  @doc """
+  Whether a decoded message asks to be served under the stateless era.
+
+  True exactly when `params._meta` declares a protocol version, which is the
+  discriminator the specification gives a dual-era server.
+
+  ## Examples
+
+      iex> meta = %{"io.modelcontextprotocol/protocolVersion" => "2026-07-28"}
+      iex> Anubis.Server.Stateless.request?(%{"params" => %{"_meta" => meta}})
+      true
+
+      iex> Anubis.Server.Stateless.request?(%{"method" => "initialize", "params" => %{}})
+      false
+  """
+  @spec request?(term()) :: boolean()
+  def request?(%{"params" => %{"_meta" => %{@protocol_version_key => version}}}), do: is_binary(version)
+  def request?(_message), do: false
+
+  @doc """
+  Narrows the versions a server declares to the ones it can serve statelessly.
+
+  Ordering follows the registry, newest first, so the list never depends on
+  how the server happened to declare its versions. This is the list a client
+  may pick from, so it feeds both `server/discover` and the
+  `UnsupportedProtocolVersion` payload.
+
+  ## Examples
+
+      iex> Anubis.Server.Stateless.supported_versions(["2025-11-25", "2026-07-28"])
+      ["2026-07-28"]
+
+      iex> Anubis.Server.Stateless.supported_versions(["2025-11-25"])
+      []
+  """
+  @spec supported_versions([String.t()]) :: [String.t()]
+  def supported_versions(declared_versions) when is_list(declared_versions) do
+    Enum.filter(Registry.stateless_versions(), &(&1 in declared_versions))
+  end
+
+  @doc """
+  Resolves the per-request context of a stateless request.
+
+  Returns an `UnsupportedProtocolVersion` error (`-32022`) when the server does
+  not serve the requested version, carrying the versions the client may retry
+  with.
+
+  ## Examples
+
+      iex> meta = %{
+      ...>   "io.modelcontextprotocol/protocolVersion" => "2026-07-28",
+      ...>   "io.modelcontextprotocol/clientCapabilities" => %{"elicitation" => %{}}
+      ...> }
+      iex> {:ok, context} = Anubis.Server.Stateless.admit(%{"params" => %{"_meta" => meta}}, ["2026-07-28"])
+      iex> {context.protocol_version, context.client_capabilities}
+      {"2026-07-28", %{"elicitation" => %{}}}
+
+      iex> meta = %{"io.modelcontextprotocol/protocolVersion" => "1900-01-01"}
+      iex> {:error, error} = Anubis.Server.Stateless.admit(%{"params" => %{"_meta" => meta}}, ["2026-07-28"])
+      iex> {error.code, error.data}
+      {-32022, %{supported: ["2026-07-28"], requested: "1900-01-01"}}
+  """
+  @spec admit(map(), [String.t()]) :: {:ok, t()} | {:error, Error.t()}
+  def admit(%{"params" => %{"_meta" => %{@protocol_version_key => version} = meta}}, declared_versions)
+      when is_binary(version) and is_list(declared_versions) do
+    supported = supported_versions(declared_versions)
+
+    with true <- version in supported,
+         {:ok, protocol_module} <- Registry.get(version) do
+      {:ok,
+       %{
+         protocol_version: version,
+         protocol_module: protocol_module,
+         client_capabilities: Map.get(meta, @client_capabilities_key, %{}),
+         client_info: Map.get(meta, @client_info_key),
+         log_level: Map.get(meta, @log_level_key)
+       }}
+    else
+      _unsupported -> {:error, Error.unsupported_protocol_version(version, supported)}
+    end
+  end
+
+  @doc """
+  Stores a request context on the transport context that travels with a
+  request.
+
+  Request scoping is what the transport context already gives us: the session
+  hands it to the scheduler, which carries it through the request queue and
+  into the frame. Nothing about the client is written to session state, so
+  nothing can leak into the next request.
+
+  ## Examples
+
+      iex> Anubis.Server.Stateless.put_context(%{assigns: %{}}, %{protocol_version: "2026-07-28"})
+      %{assigns: %{}, stateless: %{protocol_version: "2026-07-28"}}
+  """
+  @spec put_context(map() | nil, t()) :: map()
+  def put_context(transport_context, context) when is_map(transport_context) do
+    Map.put(transport_context, :stateless, context)
+  end
+
+  def put_context(_transport_context, context), do: %{stateless: context}
+
+  @doc """
+  Reads the request context back off a transport context.
+
+  Returns `nil` for a request served under the legacy era.
+
+  ## Examples
+
+      iex> Anubis.Server.Stateless.context(%{stateless: %{protocol_version: "2026-07-28"}})
+      %{protocol_version: "2026-07-28"}
+
+      iex> Anubis.Server.Stateless.context(%{assigns: %{}})
+      nil
+  """
+  @spec context(map() | nil) :: t() | nil
+  def context(%{stateless: context}) when is_map(context), do: context
+  def context(_transport_context), do: nil
+
+  @doc """
+  Builds the `server/discover` result for a server module.
+
+  `supportedVersions` narrows the server's declared versions to the stateless
+  era: a legacy version cannot be selected per request, so advertising one
+  would name a version the client could not retry with. Capabilities are
+  filtered through the dialect, exactly as the `initialize` handshake filters
+  them for legacy clients.
+
+  Cache hints are conservative — components may be registered at runtime
+  through the frame, so a result cached for longer than the current request
+  could be wrong.
+  """
+  @spec discover_result(module(), module()) :: map()
+  def discover_result(server, protocol_module) when is_atom(protocol_module) do
+    result = %{
+      "supportedVersions" => supported_versions(server.supported_protocol_versions()),
+      "capabilities" => protocol_module.server_capabilities(server.server_capabilities()),
+      "ttlMs" => @discover_ttl_ms,
+      "cacheScope" => @discover_cache_scope
+    }
+
+    maybe_put_instructions(result, server)
+  end
+
+  @doc """
+  Completes a handler result with the fields every stateless result carries.
+
+  `resultType` is mandatory in this era; `input_required` results arrive with
+  the multi round-trip requests pattern, so a completed handler result is
+  always `"complete"`. The server identity is advertised under the result
+  `_meta`, which a handler may already have populated.
+
+  ## Examples
+
+      iex> info = %{"name" => "demo", "version" => "1.0.0"}
+      iex> Anubis.Server.Stateless.shape_result(%{"tools" => []}, info)
+      %{
+        "tools" => [],
+        "resultType" => "complete",
+        "_meta" => %{"io.modelcontextprotocol/serverInfo" => %{"name" => "demo", "version" => "1.0.0"}}
+      }
+  """
+  @spec shape_result(map(), map() | nil) :: map()
+  def shape_result(result, server_info) when is_map(result) and not is_struct(result) do
+    result
+    |> Map.put_new("resultType", "complete")
+    |> put_server_info(server_info)
+  end
+
+  defp maybe_put_instructions(result, server) do
+    if Anubis.exported?(server, :server_instructions, 0) do
+      put_instructions(result, server.server_instructions())
+    else
+      result
+    end
+  end
+
+  defp put_instructions(result, nil), do: result
+  defp put_instructions(result, instructions), do: Map.put(result, "instructions", instructions)
+
+  defp put_server_info(result, nil), do: result
+
+  defp put_server_info(result, server_info) do
+    meta =
+      result
+      |> Map.get("_meta", %{})
+      |> Map.put_new(@server_info_key, server_info)
+
+    Map.put(result, "_meta", meta)
+  end
+end

--- a/test/anubis/mcp/error_test.exs
+++ b/test/anubis/mcp/error_test.exs
@@ -301,4 +301,32 @@ defmodule Anubis.MCP.ErrorTest do
       assert inspected == "#MCP.Error<empty_test>"
     end
   end
+
+  describe "resource_not_found/2" do
+    @payload %{uri: "file:///missing.txt"}
+
+    test "the legacy era keeps the MCP-specific code" do
+      error = Error.resource_not_found(@payload, :legacy)
+
+      assert error.code == -32_002
+      assert error.reason == :resource_not_found
+      assert error.data == @payload
+    end
+
+    test "the stateless era reports the JSON-RPC invalid params code" do
+      error = Error.resource_not_found(@payload, :stateless)
+
+      assert error.code == -32_602
+      assert error.reason == :invalid_params
+      assert error.data == @payload
+    end
+
+    test "each era survives a JSON-RPC round trip" do
+      for {era, code} <- [legacy: -32_002, stateless: -32_602] do
+        {:ok, encoded} = Error.to_json_rpc(Error.resource_not_found(@payload, era), 1)
+
+        assert %{"error" => %{"code" => ^code, "data" => %{"uri" => "file:///missing.txt"}}} = JSON.decode!(encoded)
+      end
+    end
+  end
 end

--- a/test/anubis/protocol/v2026_07_28_test.exs
+++ b/test/anubis/protocol/v2026_07_28_test.exs
@@ -3,6 +3,7 @@ defmodule Anubis.Protocol.V2026_07_28Test do
   use ExUnit.Case, async: true
 
   alias Anubis.MCP.Message
+  alias Anubis.Protocol.Registry
   alias Anubis.Protocol.Schema
   alias Anubis.Protocol.V2025_11_25
   alias Anubis.Protocol.V2026_07_28
@@ -330,6 +331,76 @@ defmodule Anubis.Protocol.V2026_07_28Test do
       for method <- ~w(initialize ping resources/subscribe tasks/get) do
         assert {:error, :method_not_found} = Message.validate_message(request(method), V2026_07_28)
       end
+    end
+  end
+
+  describe "request_result_schema/1" do
+    @discover_result %{
+      "resultType" => "complete",
+      "supportedVersions" => ["2026-07-28"],
+      "capabilities" => %{"tools" => %{}},
+      "ttlMs" => 0,
+      "cacheScope" => "private"
+    }
+
+    test "server/discover models the result this revision requires" do
+      schema = V2026_07_28.request_result_schema("server/discover")
+
+      assert {:ok, _} = Peri.validate(schema, @discover_result)
+      assert {:ok, _} = Peri.validate(schema, Map.put(@discover_result, "instructions", "hi"))
+    end
+
+    test "rejects a discover result missing a mandatory field" do
+      schema = V2026_07_28.request_result_schema("server/discover")
+
+      for key <- ~w(resultType supportedVersions capabilities ttlMs cacheScope) do
+        assert {:error, _} = Peri.validate(schema, Map.delete(@discover_result, key))
+      end
+    end
+
+    test "rejects a negative cache lifetime and an unknown cache scope" do
+      schema = V2026_07_28.request_result_schema("server/discover")
+
+      assert {:error, _} = Peri.validate(schema, Map.put(@discover_result, "ttlMs", -1))
+      assert {:error, _} = Peri.validate(schema, Map.put(@discover_result, "cacheScope", "shared"))
+    end
+
+    test "every other method is still unmodeled" do
+      for method <- V2026_07_28.request_methods(), method != "server/discover" do
+        assert is_nil(V2026_07_28.request_result_schema(method))
+      end
+    end
+  end
+
+  describe "era-aware decoding" do
+    @discover ~s({"jsonrpc":"2.0","id":1,"method":"server/discover","params":{"_meta":{"io.modelcontextprotocol/protocolVersion":"VERSION","io.modelcontextprotocol/clientCapabilities":{}}}}\n)
+
+    defp discover_request(version), do: String.replace(@discover, "VERSION", version)
+
+    test "decode/1 validates a message against the version it declares" do
+      [stateless | _] = Registry.stateless_versions()
+
+      assert {:ok, [decoded]} = Message.decode(discover_request(stateless))
+      assert decoded["method"] == "server/discover"
+      assert decoded["params"]["_meta"][Schema.protocol_version_key()] == stateless
+    end
+
+    test "decode/1 still rejects a stateless method that declares no version" do
+      without_meta = ~s({"jsonrpc":"2.0","id":1,"method":"server/discover","params":{}}\n)
+
+      assert {:error, :method_not_found} = Message.decode(without_meta)
+    end
+
+    test "decode/1 lets an unregistered version through so the peer can answer -32022" do
+      assert {:ok, [%{"method" => "server/discover"}]} = Message.decode(discover_request("1900-01-01"))
+    end
+
+    test "decode/1 keeps validating handshake-era messages against the latest legacy version" do
+      initialize =
+        ~s({"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25","capabilities":{},"clientInfo":{"name":"c","version":"1.0"}}}\n)
+
+      assert {:ok, [%{"method" => "initialize"}]} = Message.decode(initialize)
+      assert {:error, :method_not_found} = Message.decode(discover_request("2025-11-25"), V2025_11_25)
     end
   end
 end

--- a/test/anubis/server/stateless_test.exs
+++ b/test/anubis/server/stateless_test.exs
@@ -1,0 +1,292 @@
+defmodule Anubis.Server.StatelessTest do
+  use Anubis.MCP.Case, async: false
+
+  import ExUnit.CaptureLog
+
+  alias Anubis.Protocol.Registry, as: ProtocolRegistry
+  alias Anubis.Protocol.Schema
+  alias Anubis.Protocol.V2026_07_28
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Session
+  alias Anubis.Server.Stateless
+
+  @moduletag capture_log: true
+
+  doctest Stateless
+
+  @stateless_version "2026-07-28"
+  @client_info %{"name" => "StatelessProbe", "version" => "1.0.0"}
+
+  defmodule EchoContextTool do
+    @moduledoc false
+
+    use Anubis.Server.Component, type: :tool
+
+    alias Anubis.Server.Response
+
+    schema do
+    end
+
+    @impl true
+    def execute(_params, frame) do
+      {:reply, Response.json(Response.tool(), %{capabilities: frame.context.client_capabilities}), frame}
+    end
+  end
+
+  defmodule DualEraServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "dual-era-server",
+      version: "1.0.0",
+      capabilities: [:tools, :resources, :logging],
+      protocol_versions: ["2026-07-28", "2025-11-25"],
+      instructions: "Serves both eras."
+
+    component(EchoContextTool)
+  end
+
+  defmodule StatelessOnlyServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "stateless-only-server",
+      version: "1.0.0",
+      capabilities: [:tools],
+      protocol_versions: ["2026-07-28"]
+  end
+
+  describe "server/discover" do
+    test "advertises the stateless versions, filtered capabilities and identity" do
+      session = start_session(DualEraServer)
+
+      result = request!(session, "server/discover")
+
+      assert result["resultType"] == "complete"
+      assert result["supportedVersions"] == [@stateless_version]
+      assert result["instructions"] == "Serves both eras."
+      assert result["ttlMs"] >= 0
+      assert result["cacheScope"] in ["public", "private"]
+
+      assert result["_meta"][Stateless.server_info_key()] == %{
+               "name" => "dual-era-server",
+               "version" => "1.0.0"
+             }
+    end
+
+    test "the result validates against the dialect's result schema" do
+      session = start_session(DualEraServer)
+
+      result = request!(session, "server/discover")
+      schema = V2026_07_28.request_result_schema("server/discover")
+
+      assert {:ok, _} = Peri.validate(schema, result)
+    end
+
+    test "omits the versions the server can only serve through the handshake" do
+      session = start_session(DualEraServer)
+
+      result = request!(session, "server/discover")
+
+      for legacy <- ProtocolRegistry.legacy_versions() do
+        refute legacy in result["supportedVersions"]
+      end
+    end
+
+    test "capabilities are filtered by the dialect that served the request" do
+      session = start_session(DualEraServer)
+
+      result = request!(session, "server/discover")
+      capabilities = result["capabilities"]
+
+      assert Map.has_key?(capabilities, "tools")
+      assert capabilities == V2026_07_28.server_capabilities(DualEraServer.server_capabilities())
+    end
+  end
+
+  describe "protocol version admission" do
+    test "a version the server does not serve is rejected with -32022" do
+      session = start_session(DualEraServer)
+
+      error = error!(session, "server/discover", protocol_version: "1900-01-01")
+
+      assert error["code"] == -32_022
+      assert error["data"]["requested"] == "1900-01-01"
+      assert error["data"]["supported"] == [@stateless_version]
+    end
+
+    test "a stateless request is served without an initialize handshake" do
+      session = start_session(DualEraServer)
+
+      refute :sys.get_state(session).initialized
+
+      assert %{"resultType" => "complete"} = request!(session, "server/discover")
+    end
+
+    test "the handshake still negotiates a legacy version on the same server" do
+      session = start_session(DualEraServer)
+
+      result = initialize!(session, "2025-11-25")
+
+      assert result["protocolVersion"] == "2025-11-25"
+      refute Map.has_key?(result, "resultType")
+    end
+  end
+
+  describe "per-request client metadata" do
+    test "capabilities reach the handler and never outlive the request" do
+      session = start_session(DualEraServer)
+
+      first = call_echo_tool(session, %{"elicitation" => %{}})
+      second = call_echo_tool(session, %{})
+
+      assert first == %{"capabilities" => %{"elicitation" => %{}}}
+      assert second == %{"capabilities" => %{}}
+
+      state = :sys.get_state(session)
+      assert is_nil(state.client_capabilities)
+      assert is_nil(state.client_info)
+      assert is_nil(state.protocol_module)
+    end
+  end
+
+  describe "result shaping" do
+    test "every stateless result carries resultType and the server identity" do
+      session = start_session(DualEraServer)
+
+      result = request!(session, "tools/list")
+
+      assert result["resultType"] == "complete"
+      assert result["_meta"][Stateless.server_info_key()] == DualEraServer.server_info()
+    end
+
+    test "legacy results are left untouched" do
+      session = start_session(DualEraServer)
+      initialize!(session, "2025-11-25")
+
+      result = request!(session, "tools/list", era: :legacy)
+
+      refute Map.has_key?(result, "resultType")
+      refute Map.has_key?(result, "_meta")
+    end
+  end
+
+  describe "resource not found" do
+    test "the stateless era reports it as invalid params" do
+      session = start_session(DualEraServer)
+
+      error = error!(session, "resources/read", params: %{"uri" => "file:///missing.txt"})
+
+      assert error["code"] == -32_602
+    end
+
+    test "the legacy era keeps the code it shipped with" do
+      session = start_session(DualEraServer)
+      initialize!(session, "2025-11-25")
+
+      error = error!(session, "resources/read", params: %{"uri" => "file:///missing.txt"}, era: :legacy)
+
+      assert error["code"] == -32_002
+    end
+  end
+
+  describe "server-initiated requests" do
+    test "are refused with the missing-capability error the revision reserves" do
+      session = start_session(DualEraServer)
+
+      log =
+        capture_log(fn ->
+          send(session, {:send_roots_request, 1_000})
+          :sys.get_state(session)
+        end)
+
+      assert log =~ "missing_required_client_capability"
+      assert :sys.get_state(session).server_requests == %{}
+    end
+  end
+
+  describe "a server that declares no legacy version" do
+    test "answers initialize with -32022 instead of crashing" do
+      session = start_session(StatelessOnlyServer)
+
+      request = init_request("2025-11-25", @client_info)
+      {:ok, response} = GenServer.call(session, {:mcp_request, request, %{}})
+
+      assert %{"error" => error} = JSON.decode!(response)
+      assert error["code"] == -32_022
+      assert error["data"]["supported"] == [@stateless_version]
+      assert Process.alive?(session)
+    end
+  end
+
+  defp start_session(server_module) do
+    session_id = "stateless-#{System.unique_integer([:positive])}"
+    transport_name = Registry.transport_name(server_module, StubTransport)
+    start_supervised!({StubTransport, name: transport_name}, id: transport_name)
+
+    task_sup = Registry.task_supervisor_name(server_module)
+    start_supervised!({Task.Supervisor, name: task_sup}, id: task_sup)
+
+    session_name = Registry.session_name(server_module, session_id)
+
+    start_supervised!(
+      {Session,
+       session_id: session_id,
+       server_module: server_module,
+       name: session_name,
+       transport: [layer: StubTransport, name: transport_name],
+       task_supervisor: task_sup},
+      id: session_name
+    )
+  end
+
+  defp initialize!(session, version) do
+    request = init_request(version, @client_info)
+    {:ok, response} = GenServer.call(session, {:mcp_request, request, %{}})
+
+    GenServer.cast(session, {:mcp_notification, build_notification("notifications/initialized"), %{}})
+    sync_session(session)
+
+    JSON.decode!(response)["result"]
+  end
+
+  defp call_echo_tool(session, capabilities) do
+    params = %{"name" => "echo_context_tool", "arguments" => %{}}
+    result = request!(session, "tools/call", params: params, capabilities: capabilities)
+
+    result["content"] |> hd() |> Map.fetch!("text") |> JSON.decode!()
+  end
+
+  defp request!(session, method, opts \\ []) do
+    session |> dispatch(method, opts) |> Map.fetch!("result")
+  end
+
+  defp error!(session, method, opts) do
+    session |> dispatch(method, opts) |> Map.fetch!("error")
+  end
+
+  defp dispatch(session, method, opts) do
+    request = build_request(method, request_params(method, opts))
+    {:ok, response} = GenServer.call(session, {:mcp_request, request, %{}})
+    JSON.decode!(response)
+  end
+
+  defp request_params(_method, opts) do
+    params = Keyword.get(opts, :params, %{})
+
+    case Keyword.get(opts, :era, :stateless) do
+      :legacy -> params
+      :stateless -> Map.put(params, "_meta", request_meta(opts))
+    end
+  end
+
+  defp request_meta(opts) do
+    %{
+      Schema.protocol_version_key() => Keyword.get(opts, :protocol_version, @stateless_version),
+      "io.modelcontextprotocol/clientCapabilities" => Keyword.get(opts, :capabilities, %{}),
+      "io.modelcontextprotocol/clientInfo" => @client_info
+    }
+  end
+
+  defp sync_session(session), do: :sys.get_state(session)
+end

--- a/test/anubis/server/stateless_test.exs
+++ b/test/anubis/server/stateless_test.exs
@@ -258,11 +258,15 @@ defmodule Anubis.Server.StatelessTest do
   end
 
   defp request!(session, method, opts \\ []) do
-    session |> dispatch(method, opts) |> Map.fetch!("result")
+    response = dispatch(session, method, opts)
+    assert %{"result" => result} = response
+    result
   end
 
   defp error!(session, method, opts) do
-    session |> dispatch(method, opts) |> Map.fetch!("error")
+    response = dispatch(session, method, opts)
+    assert %{"error" => error} = response
+    error
   end
 
   defp dispatch(session, method, opts) do


### PR DESCRIPTION
## Problem

#269 registered the 2026-07-28 dialect but served nothing on the wire. `server/discover` had no handler, `request_result_schema/1` returned `nil` everywhere, the reserved `-32021`/`-32022` constructors had no caller, and `decode/1` validated every message against the newest *legacy* version. A stateless request died as `method_not_found` before reaching a session.

It also left a live defect: `Session` hard-matched `{:ok, _, _}` on `Registry.negotiate/2`, which #269 taught to return bare `:error`. A server declaring only 2026-07-28 crashed on every `initialize`.

## Solution

Second slice of #263 — the era is served, transport-independently.

- A request is stateless iff `params._meta` declares a protocol version, the discriminator the spec gives a dual-era server. `decode/1` validates each message against the version it declares; an unregistered version resolves to the newest stateless dialect, so the session answers `-32022` rather than a parse error.
- `Anubis.Server.Stateless` owns admission, the discover result and result shaping. Its context rides on the transport context — already request-scoped through the scheduler queue into the frame — so client capabilities and identity never reach session state.
- `server/discover` routes through `Handlers` like any other method, inheriting the scheduler and telemetry.
- Stateless results gain `resultType` and `_meta` server identity at the scheduler's single reply point; legacy results are untouched.
- `-32602` replaces `-32002` for resource-not-found under this era only; `-32021` replaces the untyped string at the one site already detecting a missing client capability.

## Rationale

`supportedVersions` comes from the same helper as `-32022`'s `supported`, and omits legacy versions: one cannot be selected per request, so advertising it would name a version the client could not retry with.

`ttlMs: 0` / `cacheScope: "private"` are conservative — components may be registered at runtime through the frame, so a longer-lived cache could be wrong. Step 6 makes them configurable.

`Registry.latest_module/1` fills the gap beside `latest_version/1`, so the unregistered-version fallback comes from the registry, not a literal.

Deferred by intent: the Streamable HTTP binding is step 3, so the plug still rejects stateless versions and its containment test is unchanged; `subscriptions/listen` step 4; `InputRequiredResult` step 5; the remaining cacheable results step 6; the client era probe step 7.