### PR TITLE
feat(server): optional per-connection instructions and tool surface

### DIFF
--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -192,6 +192,18 @@ defmodule Anubis.Server do
   @callback server_instructions() :: String.t() | nil
 
   @doc """
+  Returns the instructions for *this* connection, given the frame the handshake will answer with.
+
+  Optional, and takes precedence over `c:server_instructions/0` when defined. The frame carries
+  the transport's assigns — whatever a `Plug` put on the connection before the request reached
+  the server — so a server whose guidance depends on who is asking can vary it here.
+
+  `c:init/2` cannot serve this purpose: it runs when the client acknowledges the handshake,
+  after the `initialize` result carrying the instructions has already been sent.
+  """
+  @callback server_instructions(frame :: Anubis.Server.Frame.t()) :: String.t() | nil
+
+  @doc """
   Called when a session is being auto-recovered after expiry.
 
   Invoked during `auto_initialize/1` instead of the normal client handshake.
@@ -275,7 +287,8 @@ defmodule Anubis.Server do
   """
   @callback serialize_assigns(assigns :: map()) :: map()
 
-  @optional_callbacks handle_notification: 2,
+  @optional_callbacks server_instructions: 1,
+                      handle_notification: 2,
                       handle_info: 2,
                       handle_call: 3,
                       handle_cast: 2,

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -647,7 +647,6 @@ defmodule Anubis.Server do
 
     resources_config =
       %{}
-      # Notification Functions — all use send(self(), ...) to the current Session process
       |> then(&if(is_nil(subscribe?), do: &1, else: Map.put(&1, :subscribe, subscribe?)))
       |> then(&if(is_nil(list_changed?), do: &1, else: Map.put(&1, :listChanged, list_changed?)))
 
@@ -727,6 +726,8 @@ defmodule Anubis.Server do
   end
 
   def validate_server_info!(_, name, version) when is_binary(name) and is_binary(version), do: :ok
+
+  # Notification Functions — all use send(self(), ...) to the current Session process
 
   @doc """
   Sends a resources list changed notification.

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -216,6 +216,36 @@ defmodule Anubis.Server do
   @callback server_instructions(frame :: Frame.t()) :: String.t() | nil
 
   @doc """
+  Returns the tools *this* connection may list and call, given its frame.
+
+  Optional. It is applied to the compile-time components concatenated with the frame's runtime
+  tools, every time the list is built — which is both `tools/list` and the lookup `tools/call`
+  does, so a tool withheld here cannot be reached by name either.
+
+  The frame carries the transport's assigns, so a server whose surface depends on who is asking
+  resolves it here rather than at registration. `c:init/2` cannot serve this purpose: it runs
+  once per session, and on a session restored from a store it runs before the request's assigns
+  are attached.
+
+  Return the tools unchanged to serve everyone the same surface. A tool may also be returned
+  *rewritten* — a description or a schema that names something one caller may not be shown is a
+  connection-level decision, and the struct is the place to make it.
+
+  ## Examples
+
+      @impl Anubis.Server
+      def server_tools(tools, frame) do
+        if frame.assigns[:plan] == :enterprise do
+          tools
+        else
+          Enum.reject(tools, &(&1.name == "bulk_export"))
+        end
+      end
+
+  """
+  @callback server_tools(tools :: [Tool.t()], frame :: Frame.t()) :: [Tool.t()]
+
+  @doc """
   Called when a session is being auto-recovered after expiry.
 
   Invoked during `auto_initialize/1` instead of the normal client handshake.
@@ -300,6 +330,7 @@ defmodule Anubis.Server do
   @callback serialize_assigns(assigns :: map()) :: map()
 
   @optional_callbacks server_instructions: 1,
+                      server_tools: 2,
                       handle_notification: 2,
                       handle_info: 2,
                       handle_call: 3,

--- a/lib/anubis/server.ex
+++ b/lib/anubis/server.ex
@@ -200,8 +200,20 @@ defmodule Anubis.Server do
 
   `c:init/2` cannot serve this purpose: it runs when the client acknowledges the handshake,
   after the `initialize` result carrying the instructions has already been sent.
+
+  ## Examples
+
+      @impl Anubis.Server
+      def server_instructions(frame) do
+        case frame.assigns[:plan] do
+          :enterprise -> "You may call `bulk_export`. Confirm the range before exporting."
+          _ -> "Exports run one record at a time."
+        end
+      end
+
+  Return `nil` to omit the field from the `initialize` result.
   """
-  @callback server_instructions(frame :: Anubis.Server.Frame.t()) :: String.t() | nil
+  @callback server_instructions(frame :: Frame.t()) :: String.t() | nil
 
   @doc """
   Called when a session is being auto-recovered after expiry.
@@ -604,6 +616,7 @@ defmodule Anubis.Server do
 
     resources_config =
       %{}
+      # Notification Functions — all use send(self(), ...) to the current Session process
       |> then(&if(is_nil(subscribe?), do: &1, else: Map.put(&1, :subscribe, subscribe?)))
       |> then(&if(is_nil(list_changed?), do: &1, else: Map.put(&1, :listChanged, list_changed?)))
 
@@ -683,8 +696,6 @@ defmodule Anubis.Server do
   end
 
   def validate_server_info!(_, name, version) when is_binary(name) and is_binary(version), do: :ok
-
-  # Notification Functions — all use send(self(), ...) to the current Session process
 
   @doc """
   Sends a resources list changed notification.

--- a/lib/anubis/server/handlers.ex
+++ b/lib/anubis/server/handlers.ex
@@ -49,7 +49,15 @@ defmodule Anubis.Server.Handlers do
   end
 
   def get_server_tools(module, frame) do
-    Enum.sort_by(module.__components__(:tool) ++ Frame.get_tools(frame), & &1.name)
+    tools = Enum.sort_by(module.__components__(:tool) ++ Frame.get_tools(frame), & &1.name)
+
+    # Resolved on every list and every call, because the frame is what carries the request's
+    # assigns — a surface decided at registration cannot see them.
+    if Anubis.exported?(module, :server_tools, 2) do
+      module.server_tools(tools, frame)
+    else
+      tools
+    end
   end
 
   def get_server_prompts(module, frame) do

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -1086,13 +1086,7 @@ defmodule Anubis.Server.Session do
     end)
   end
 
-  # `server_instructions/0` is resolved once, when the session process starts, so it cannot know
-  # who is connecting. A server that needs to vary its guidance per connection defines
-  # `server_instructions/1`, resolved here instead: the transport merges the request's assigns
-  # into the frame before this request is dispatched, so they are available now.
-  #
-  # `init/2` is not an alternative — it runs on `notifications/initialized`, after this result
-  # has been sent.
+  # Resolved here, not at session start, so the frame carries this request's assigns.
   defp connection_instructions(%{server_module: module} = state) do
     if Anubis.exported?(module, :server_instructions, 1) do
       module.server_instructions(prepare_frame(state))

--- a/lib/anubis/server/session.ex
+++ b/lib/anubis/server/session.ex
@@ -689,7 +689,7 @@ defmodule Anubis.Server.Session do
           "serverInfo" => state.server_info,
           "capabilities" => protocol_module.server_capabilities(state.capabilities)
         },
-        state.instructions
+        connection_instructions(state)
       )
 
     Logging.server_event("initializing", %{
@@ -1084,6 +1084,21 @@ defmodule Anubis.Server.Session do
     Enum.map(requests, fn {id, req} ->
       %{id: id, method: req[:method]}
     end)
+  end
+
+  # `server_instructions/0` is resolved once, when the session process starts, so it cannot know
+  # who is connecting. A server that needs to vary its guidance per connection defines
+  # `server_instructions/1`, resolved here instead: the transport merges the request's assigns
+  # into the frame before this request is dispatched, so they are available now.
+  #
+  # `init/2` is not an alternative — it runs on `notifications/initialized`, after this result
+  # has been sent.
+  defp connection_instructions(%{server_module: module} = state) do
+    if Anubis.exported?(module, :server_instructions, 1) do
+      module.server_instructions(prepare_frame(state))
+    else
+      state.instructions
+    end
   end
 
   defp maybe_put_instructions(result, nil), do: result

--- a/test/anubis/server/handlers_server_tools_test.exs
+++ b/test/anubis/server/handlers_server_tools_test.exs
@@ -1,0 +1,103 @@
+defmodule Anubis.Server.HandlersServerToolsTest do
+  @moduledoc """
+  `server_tools/2`: the surface one connection is served, decided from its frame.
+
+  What makes it necessary is that neither of the two places a server could otherwise decide
+  this can see the caller. Registration happens at compile time, and `init/2` runs once per
+  session — before the request's assigns are attached, on a session restored from a store.
+  """
+  use ExUnit.Case, async: true
+
+  alias Anubis.Server.Component.Tool
+  alias Anubis.Server.Frame
+  alias Anubis.Server.Handlers
+  alias Anubis.Server.Response
+
+  defmodule PlainServer do
+    @moduledoc false
+    def __components__(:tool) do
+      [
+        %Tool{name: "read", description: "Reads a record."},
+        %Tool{name: "bulk_export", description: "Exports every record at once."}
+      ]
+    end
+  end
+
+  defmodule TieredServer do
+    @moduledoc false
+    def __components__(:tool), do: PlainServer.__components__(:tool)
+
+    def handle_tool_call(name, _params, frame) do
+      {:reply, Response.text(Response.tool(), name <> " ran"), frame}
+    end
+
+    def server_tools(tools, frame) do
+      case frame.assigns[:plan] do
+        :enterprise ->
+          tools
+
+        _other ->
+          tools
+          |> Enum.reject(&(&1.name == "bulk_export"))
+          |> Enum.map(&%{&1 | description: "Reads a record. One at a time."})
+      end
+    end
+  end
+
+  defp list(server, frame) do
+    {:reply, %{"tools" => tools}, _frame} =
+      Handlers.handle(%{"method" => "tools/list"}, server, frame)
+
+    tools
+  end
+
+  defp call(server, frame, name) do
+    Handlers.handle(
+      %{"method" => "tools/call", "params" => %{"name" => name, "arguments" => %{}}},
+      server,
+      frame
+    )
+  end
+
+  describe "a server that does not export it" do
+    test "is served its registered tools, unchanged" do
+      assert ["bulk_export", "read"] =
+               PlainServer |> list(Frame.new()) |> Enum.map(& &1.name) |> Enum.sort()
+    end
+  end
+
+  describe "a server that does export it" do
+    test "the frame decides which tools the connection lists" do
+      enterprise = Frame.new(%{plan: :enterprise})
+      free = Frame.new(%{plan: :free})
+
+      assert "bulk_export" in Enum.map(list(TieredServer, enterprise), & &1.name)
+      refute "bulk_export" in Enum.map(list(TieredServer, free), & &1.name)
+    end
+
+    test "a tool withheld from a connection cannot be called by name either" do
+      # The same list answers `tools/call`'s lookup, so withholding is not merely cosmetic —
+      # which is the whole reason the hook belongs here and not in `handle_list`.
+      assert {:error, %{reason: :invalid_params} = error, _frame} =
+               call(TieredServer, Frame.new(%{plan: :free}), "bulk_export")
+
+      assert error.data.message =~ "Tool not found: bulk_export"
+
+      # …and the same name still resolves for a connection that may have it, which is what
+      # makes the refusal above a decision about the caller rather than about the tool.
+      assert {:reply, %{"content" => [%{"text" => "bulk_export ran"}]}, _frame} =
+               call(TieredServer, Frame.new(%{plan: :enterprise}), "bulk_export")
+    end
+
+    test "a tool may be returned rewritten rather than withheld" do
+      [read] = list(TieredServer, Frame.new(%{plan: :free}))
+
+      assert read.description == "Reads a record. One at a time."
+
+      assert [%{description: "Reads a record."}, _] =
+               TieredServer
+               |> list(Frame.new(%{plan: :enterprise}))
+               |> Enum.sort_by(& &1.name, :desc)
+    end
+  end
+end

--- a/test/anubis/server/session_instructions_test.exs
+++ b/test/anubis/server/session_instructions_test.exs
@@ -39,6 +39,26 @@ defmodule Anubis.Server.SessionInstructionsTest do
       capabilities: [:tools]
   end
 
+  defmodule InstructionsPerConnectionServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "instructions-per-connection-server",
+      version: "1.0.0",
+      capabilities: [:tools]
+
+    @impl Anubis.Server
+    def server_instructions, do: "Static fallback"
+
+    @impl Anubis.Server
+    def server_instructions(frame) do
+      case frame.assigns[:audience] do
+        nil -> "Instructions for an unknown caller"
+        audience -> "Instructions for #{audience}"
+      end
+    end
+  end
+
   describe "instructions via use option" do
     test "initialize response includes instructions" do
       {session, _transport} = start_session(InstructionsViaOptionServer)
@@ -84,6 +104,34 @@ defmodule Anubis.Server.SessionInstructionsTest do
     end
   end
 
+  describe "instructions per connection" do
+    test "the frame's assigns decide what the handshake answers with" do
+      {session, _transport} = start_session(InstructionsPerConnectionServer)
+
+      result = send_initialize(session, %{assigns: %{audience: "a support agent"}})
+
+      assert result["instructions"] == "Instructions for a support agent"
+    end
+
+    test "a connection carrying no assigns still gets an answer" do
+      {session, _transport} = start_session(InstructionsPerConnectionServer)
+
+      assert send_initialize(session)["instructions"] == "Instructions for an unknown caller"
+    end
+
+    test "arity 1 takes precedence over arity 0" do
+      {session, _transport} = start_session(InstructionsPerConnectionServer)
+
+      refute send_initialize(session)["instructions"] == "Static fallback"
+    end
+
+    test "a server defining only arity 0 is unaffected" do
+      {session, _transport} = start_session(InstructionsViaCallbackServer)
+
+      assert send_initialize(session)["instructions"] == "Dynamic instructions from callback"
+    end
+  end
+
   # Helpers
 
   defp start_session(server_module) do
@@ -110,9 +158,9 @@ defmodule Anubis.Server.SessionInstructionsTest do
     {session, transport}
   end
 
-  defp send_initialize(session) do
+  defp send_initialize(session, transport_context \\ %{}) do
     request = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
-    {:ok, response_json} = GenServer.call(session, {:mcp_request, request, %{}})
+    {:ok, response_json} = GenServer.call(session, {:mcp_request, request, transport_context})
     response = JSON.decode!(response_json)
     response["result"]
   end

--- a/test/anubis/server/session_server_tools_test.exs
+++ b/test/anubis/server/session_server_tools_test.exs
@@ -1,0 +1,184 @@
+defmodule Anubis.Server.SessionServerToolsTest do
+  @moduledoc """
+  `server_tools/2` over the protocol path, as a client meets it.
+
+  `Anubis.Server.HandlersServerToolsTest` covers the callback's contract against
+  `Handlers.handle/3`. This file answers the question that one cannot: whether the surface a
+  *session* serves follows the frame of the request being answered, through `initialize`, the
+  acknowledgement, and the two methods that read the tool list.
+  """
+  use Anubis.MCP.Case, async: false
+
+  alias Anubis.Server.Component
+  alias Anubis.Server.Registry
+  alias Anubis.Server.Response
+  alias Anubis.Server.Session
+  alias Anubis.Test.SyncHelpers
+
+  @moduletag capture_log: true
+
+  defmodule ReadTool do
+    @moduledoc "Reads one record."
+
+    use Component, type: :tool
+
+    schema do
+    end
+
+    @impl true
+    def execute(_params, frame), do: {:reply, Response.text(Response.tool(), "read"), frame}
+  end
+
+  defmodule BulkExportTool do
+    @moduledoc "Exports every record at once."
+
+    use Component, type: :tool
+
+    schema do
+    end
+
+    @impl true
+    def execute(_params, frame), do: {:reply, Response.text(Response.tool(), "exported"), frame}
+  end
+
+  defmodule TieredServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "tiered-server",
+      version: "1.0.0",
+      capabilities: [:tools]
+
+    component(ReadTool, name: "read")
+    component(BulkExportTool, name: "bulk_export")
+
+    @impl Anubis.Server
+    def server_tools(tools, frame) do
+      case frame.assigns[:plan] do
+        :enterprise ->
+          tools
+
+        _other ->
+          tools
+          |> Enum.reject(&(&1.name == "bulk_export"))
+          |> Enum.map(&%{&1 | description: "Reads a record. One at a time."})
+      end
+    end
+  end
+
+  defmodule PlainServer do
+    @moduledoc false
+
+    use Anubis.Server,
+      name: "plain-server",
+      version: "1.0.0",
+      capabilities: [:tools]
+
+    component(ReadTool, name: "read")
+    component(BulkExportTool, name: "bulk_export")
+  end
+
+  describe "a server that does not export the callback" do
+    test "serves a session its registered tools, unchanged" do
+      session = connect(PlainServer)
+
+      assert ["bulk_export", "read"] = session |> list_tools() |> Enum.map(& &1["name"]) |> Enum.sort()
+    end
+  end
+
+  describe "a server that does export it" do
+    test "the connection's assigns decide the tools its session lists" do
+      enterprise = connect(TieredServer, %{plan: :enterprise})
+      free = connect(TieredServer, %{plan: :free})
+
+      assert "bulk_export" in Enum.map(list_tools(enterprise), & &1["name"])
+      refute "bulk_export" in Enum.map(list_tools(free), & &1["name"])
+    end
+
+    test "a tool withheld from a connection cannot be called by name either" do
+      # The list and the call resolve through the same function, so withholding is not merely
+      # cosmetic — which is what makes this the protocol-level statement of the contract.
+      assert %{"error" => error} = call_tool(connect(TieredServer, %{plan: :free}), "bulk_export")
+      assert error["data"]["message"] == "Tool not found: bulk_export"
+
+      assert %{"result" => result} =
+               call_tool(connect(TieredServer, %{plan: :enterprise}), "bulk_export")
+
+      assert [%{"text" => "exported"}] = result["content"]
+    end
+
+    test "a tool may reach a connection rewritten rather than withheld" do
+      [read] = list_tools(connect(TieredServer, %{plan: :free}))
+
+      assert read["description"] == "Reads a record. One at a time."
+
+      assert %{"description" => "Reads one record."} =
+               TieredServer
+               |> connect(%{plan: :enterprise})
+               |> list_tools()
+               |> Enum.find(&(&1["name"] == "read"))
+    end
+  end
+
+  # Helpers
+
+  # The assigns ride on every request, not only the handshake: the frame a method is answered
+  # with is built from the transport context of *that* request.
+  defp connect(server_module, assigns \\ %{}) do
+    session_id = "test-#{System.unique_integer([:positive])}"
+    transport_name = Registry.transport_name(server_module, StubTransport)
+    start_once({StubTransport, name: transport_name}, transport_name)
+
+    task_sup = Registry.task_supervisor_name(server_module)
+    start_once({Task.Supervisor, name: task_sup}, task_sup)
+
+    session_name = Registry.session_name(server_module, session_id)
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: session_id,
+         server_module: server_module,
+         name: session_name,
+         transport: [layer: StubTransport, name: transport_name],
+         task_supervisor: task_sup},
+        id: session_name
+      )
+
+    context = %{assigns: assigns}
+    request = init_request("2025-03-26", %{"name" => "TestClient", "version" => "1.0.0"})
+    {:ok, _} = GenServer.call(session, {:mcp_request, request, context})
+
+    :ok =
+      GenServer.cast(
+        session,
+        {:mcp_notification, build_notification("notifications/initialized", %{}), context}
+      )
+
+    SyncHelpers.await_state(session, & &1.initialized)
+
+    {session, context}
+  end
+
+  # Two connections in one test share a server module, and the transport and task supervisor
+  # are named after it.
+  defp start_once(spec, id) do
+    case start_supervised(spec, id: id) do
+      {:ok, pid} -> pid
+      {:error, {{:already_started, pid}, _}} -> pid
+      {:error, {:already_started, pid}} -> pid
+    end
+  end
+
+  defp list_tools(connection), do: send_request(connection, "tools/list")["result"]["tools"]
+
+  defp call_tool(connection, name) do
+    send_request(connection, "tools/call", %{"name" => name, "arguments" => %{}})
+  end
+
+  defp send_request({session, context}, method, params \\ %{}) do
+    request = build_request(method, params)
+    {:ok, response_json} = GenServer.call(session, {:mcp_request, request, context})
+    JSON.decode!(response_json)
+  end
+end


### PR DESCRIPTION
Two optional callbacks that let a server answer the handshake and the tool list from the frame, rather than from what was known at compile time or at session start.

Both are fully backwards compatible: a server that defines neither keeps the existing paths exactly.

## `server_instructions/1`

`server_instructions/0` is resolved once, in `Session.init/1`, when the session process starts and no request exists yet. A server whose guidance depends on *who* is connecting therefore cannot vary it — and `init/2` is not an alternative, because it runs on `notifications/initialized`, after the `initialize` result carrying the instructions has already been sent.

The arity-1 callback is resolved at initialize time, where `handle_call({:mcp_request, ...})` has already merged the transport's assigns into the frame. Arity 1 wins when both are defined.

## `server_tools/2`

`tools/list` is answered from `__components__(:tool) ++ Frame.get_tools(frame)`, concatenated without consulting the frame, so a tool's description and its schemas are one string each: what is written there reaches every client, whoever it is.

Neither place a server could otherwise decide this can see the caller. Registration is compile time. `init/2` runs once per session — and on a session restored from a store it runs before the request's assigns are attached, so a surface decided there is decided blind.

`server_tools/2` takes the built list and the frame, resolved in `Handlers.get_server_tools/2`. That is deliberately the function `tools/call` also uses for its lookup, so a tool withheld from a connection cannot be reached by name either — the decision is about the caller, in one place, rather than a cosmetic filter on the listing.

A tool may also be returned **rewritten** rather than withheld: a sentence one caller may not be shown is a connection-level decision, and `%Tool{}` is where to make it.

```elixir
@impl Anubis.Server
def server_tools(tools, frame) do
  if frame.assigns[:plan] == :enterprise do
    tools
  else
    Enum.reject(tools, &(&1.name == "bulk_export"))
  end
end
```

## Why both

The motivating case is one server serving two platforms whose rules differ about what may be put in front of a user — one of them forbidding a plugin from displaying prices or offering a way to pay.

We shipped the instructions half first and found it was not enough: the tool descriptions and schemas are read by the model too, and one of ours was telling it, in an input-schema field description, to suggest a paid upgrade. The only repair available without this callback was to write that prose out of the descriptions for *everybody*, which costs every other client a sentence it is entitled to. That outcome is what this exists to avoid.

## Tests

`test/anubis/server/session_instructions_test.exs` and `test/anubis/server/handlers_server_tools_test.exs`. Full suite: 76 doctests, 1049 tests, 0 failures.